### PR TITLE
fix: エスケープ文字に'あ'などを指定するとEscapeLikeWithCharが正常に動作しない

### DIFF
--- a/sql-escape/escape.go
+++ b/sql-escape/escape.go
@@ -1,6 +1,9 @@
 package sql_escape
 
-import "strings"
+import (
+	"strings"
+	"unicode/utf8"
+)
 
 // EscapeLike escapes the special characters in the SQL Like statement.
 // The escape character is regarded as '\\'.
@@ -9,7 +12,12 @@ func EscapeLike(s string) string {
 }
 
 // EscapeLikeWithChar escapes the special characters in the SQL Like statement.
+// Set 'c' to a character with a length of 1 as rune.
 func EscapeLikeWithChar(s string, c rune) string {
+	if utf8.RuneLen(c) != 1 {
+		panic("set 'c' to a character with a length of 1 as rune.")
+	}
+
 	var b strings.Builder
 	b.Grow(2 * (len(s)))
 

--- a/sql-escape/escape_test.go
+++ b/sql-escape/escape_test.go
@@ -79,6 +79,7 @@ func TestEscapeLikeWithChar(t *testing.T) {
 			name: "no-escape",
 			args: args{
 				s: "t",
+				c: '!',
 			},
 			want: "t",
 		},
@@ -86,6 +87,7 @@ func TestEscapeLikeWithChar(t *testing.T) {
 			name: "empty",
 			args: args{
 				s: "",
+				c: '!',
 			},
 			want: "",
 		},


### PR DESCRIPTION
エスケープ文字がruneとして2以上のことを想定していないから。

そのようなケースはサポート外である旨を明記。
そういう使い方をしたらpanicさせる。