### PR TITLE
feat: ulid.ParseStrict()

### DIFF
--- a/ulid/ulid.go
+++ b/ulid/ulid.go
@@ -61,6 +61,18 @@ func Parse(s string) (ULID, error) {
 	return u, nil
 }
 
+// ParseStrict parses an encoded ULID, returning an error in case of failure.
+//
+// It is like Parse, but additionally validates that the parsed ULID consists
+// only of valid base32 characters. It is slightly slower than Parse.
+func ParseStrict(id string) (ULID, error) {
+	okid, err := oklogulid.ParseStrict(id)
+	if err != nil {
+		return ULID{}, err
+	}
+	return ULID(okid), nil
+}
+
 func (u ULID) String() string {
 	return oklogulid.ULID(u).String()
 }

--- a/ulid/ulid_test.go
+++ b/ulid/ulid_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 
+	oklogulid "github.com/oklog/ulid/v2"
+
 	"github.com/88labs/go-utils/ulid"
 )
 
@@ -17,6 +19,61 @@ func TestParse(t *testing.T) {
 	}{
 		{"zero", "00000000000000000000000000", "ulid is zero"},
 		{"ok", "0000XSNJG0MQJHBF4QX1EFD6Y3", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := ulid.Parse(tt.input)
+			if len(tt.err) == 0 {
+				if err != nil {
+					t.Fatalf("want no err, but has err %v", err)
+				}
+				if id.IsZero() {
+					t.Fatal("ulid is zero")
+				}
+			}
+
+			if len(tt.err) > 0 {
+				if err == nil {
+					t.Fatalf("want %v, but %v", tt.err, err)
+				}
+				if !strings.Contains(err.Error(), tt.err) {
+					t.Fatalf("want %v, but %v", tt.err, err)
+				}
+			}
+		})
+	}
+}
+
+func TestParseStrict(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{"zero", "00000000000000000000000000", "ulid is zero"},
+		{"ok", "0000XSNJG0MQJHBF4QX1EFD6Y3", ""},
+	}
+	base := "0000XSNJG0MQJHBF4QX1EFD6Y3"
+	for i := 0; i < oklogulid.EncodedSize; i++ {
+		tests = append(tests, struct {
+			name  string
+			input string
+			err   string
+		}{
+			name:  fmt.Sprintf("Invalid 0xFF at index %d", i),
+			input: base[:i] + "\xff" + base[i+1:],
+			err:   oklogulid.ErrInvalidCharacters.Error(),
+		})
+		tests = append(tests, struct {
+			name  string
+			input string
+			err   string
+		}{
+			name:  fmt.Sprintf("Invalid 0x00 at index %d", i),
+			input: base[:i] + "\x00" + base[i+1:],
+			err:   oklogulid.ErrInvalidCharacters.Error(),
+		})
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`ulid.ParseStrict()` の実装
基本的には `oklog/ulid/v2` の wrapperなので特別な処理はありません