### PR TITLE
chore: awss3 SelectCSVHeaders options WithCSVInput copy

### DIFF
--- a/aws/awss3/awss3.go
+++ b/aws/awss3/awss3.go
@@ -362,7 +362,16 @@ func SelectCSVAll(ctx context.Context, region awsconfig.Region, bucketName Bucke
 // Get CSV headers
 // Valid options: CompressionType
 func SelectCSVHeaders(ctx context.Context, region awsconfig.Region, bucketName BucketName, key Key, opts ...s3selectcsv.OptionS3SelectCSV) ([]string, error) {
-	opts = append(opts, s3selectcsv.WithCSVInput(types.CSVInput{FileHeaderInfo: types.FileHeaderInfoNone}))
+	c := s3selectcsv.GetS3SelectCSVConf(opts...)
+	opts = append(opts, s3selectcsv.WithCSVInput(types.CSVInput{
+		AllowQuotedRecordDelimiter: c.CSVInput.AllowQuotedRecordDelimiter,
+		Comments:                   c.CSVInput.Comments,
+		FieldDelimiter:             c.CSVInput.FieldDelimiter,
+		FileHeaderInfo:             types.FileHeaderInfoNone,
+		QuoteCharacter:             c.CSVInput.QuoteCharacter,
+		QuoteEscapeCharacter:       c.CSVInput.QuoteEscapeCharacter,
+		RecordDelimiter:            c.CSVInput.RecordDelimiter,
+	}))
 	opts = append(opts, s3selectcsv.WithSkipByteSize(0))
 	var buf bytes.Buffer
 	if err := SelectCSVAll(ctx, region, bucketName, key, SelectCSVLimit1Query, &buf, opts...); err != nil {


### PR DESCRIPTION
awss3.SelectCSVHeaders() の WithCSVInput optionを上書きしないように修正