### PR TITLE
Added dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,3 +49,10 @@ updates:
     time: "12:00"
     timezone: Asia/Tokyo
   open-pull-requests-limit: 10
+- package-ecosystem: 'github-actions'
+  directory: '/'
+  schedule:
+    interval: daily
+    time: "12:00"
+    timezone: Asia/Tokyo
+  open-pull-requests-limit: 10


### PR DESCRIPTION
How about using dependabot for GitHub Actions in this way?
When this works, a PullRequest is created as follows:
- https://togithub.com/ruby/bigdecimal/pull/242