### PR TITLE
feat: s3 presign: add option

### DIFF
--- a/aws/awss3/awss3.go
+++ b/aws/awss3/awss3.go
@@ -257,11 +257,7 @@ func Presign(ctx context.Context, region awsconfig.Region, bucketName BucketName
 		Key:    key.AWSString(),
 	}
 	if c.PresignFileName != "" {
-		input.ResponseContentDisposition = aws.String(ResponseContentDisposition(c.PresignFileName))
-		// memo: If type is specified, it is overridden as the behavior in the new version.
-		if c.PresignFileType != nil {
-			input.ResponseContentType = aws.String(ResponseContentDispositionMulti(*c.PresignFileType, c.PresignFileName))
-		}
+		input.ResponseContentDisposition = aws.String(ResponseContentDisposition(c.ContentDispositionType, c.PresignFileName))
 	}
 	ps := s3.NewPresignClient(client)
 	resp, err := ps.PresignGetObject(ctx, input, func(o *s3.PresignOptions) {
@@ -273,26 +269,15 @@ func Presign(ctx context.Context, region awsconfig.Region, bucketName BucketName
 	return resp.URL, nil
 }
 
-// ResponseContentDisposition
-// Setting ResponseContentDisposition to support file names with multibyte characters
-func ResponseContentDisposition(fileName string) string {
-	return fmt.Sprintf(`attachment; filename*=UTF-8''%s`, url.PathEscape(fileName))
-}
-
-// ResponseContentDispositionMulti
-// Setting ResponseContentDisposition to support file names with multibyte characters
-func ResponseContentDispositionMulti(tp s3presigned.ContentDispositionType, fileName string) string {
-	switch {
-	case tp == s3presigned.PresignFileTypeInline && fileName == "":
-		return string(s3presigned.PresignFileTypeInline)
-	case tp == s3presigned.PresignFileTypeInline && fileName != "":
-		return fmt.Sprintf(`inline; filename*=UTF-8''%s`, url.PathEscape(fileName))
-	case tp == s3presigned.PresignFileTypeAttachment && fileName == "":
-		return string(s3presigned.PresignFileTypeAttachment)
-	case tp == s3presigned.PresignFileTypeAttachment && fileName != "":
-		return fmt.Sprintf(`attachment; filename*=UTF-8''%s`, url.PathEscape(fileName))
+func ResponseContentDisposition(tp s3presigned.ContentDispositionType, fileName string) string {
+	var dispositionType string
+	switch tp {
+	case s3presigned.ContentDispositionTypeAttachment:
+		dispositionType = "attachment"
+	case s3presigned.ContentDispositionTypeInline:
+		dispositionType = "inline"
 	}
-	return ""
+	return fmt.Sprintf(`%s; filename*=UTF-8''%s`, dispositionType, url.PathEscape(fileName))
 }
 
 // Copy copies an Amazon S3 object from one bucket to same.

--- a/aws/awss3/awss3_test.go
+++ b/aws/awss3/awss3_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/88labs/go-utils/aws/awsconfig"
 	"github.com/88labs/go-utils/aws/awss3"
 	"github.com/88labs/go-utils/aws/awss3/options/s3download"
+	"github.com/88labs/go-utils/aws/awss3/options/s3presigned"
 	"github.com/88labs/go-utils/aws/ctxawslocal"
 	"github.com/88labs/go-utils/ulid"
 )
@@ -291,6 +292,50 @@ func TestResponseContentDisposition(t *testing.T) {
 		actual := awss3.ResponseContentDisposition(fileName)
 		assert.NotEmpty(t, actual)
 	})
+}
+
+func TestResponseContentDispositionMulti(t *testing.T) {
+	const fileName = ",あいうえお　牡蠣喰家来 サシスセソ@+$_-^|+{}"
+
+	cases := map[string]struct {
+		tp       s3presigned.ContentDispositionType
+		fileName string
+		emptyFLG bool
+	}{
+		"inline": {
+			fileName: "",
+			tp:       s3presigned.PresignFileTypeInline,
+		},
+		"inline&filename": {
+			tp:       s3presigned.PresignFileTypeInline,
+			fileName: fileName,
+		},
+		"attachment": {
+			tp:       s3presigned.PresignFileTypeAttachment,
+			fileName: "",
+		},
+		"attachment&filename": {
+			tp:       s3presigned.PresignFileTypeAttachment,
+			fileName: fileName,
+		},
+		"empty": {
+			tp:       "",
+			fileName: "",
+			emptyFLG: true,
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := awss3.ResponseContentDispositionMulti(c.tp, c.fileName)
+			switch c.emptyFLG {
+			case true:
+				assert.Empty(t, actual)
+			default:
+				assert.NotEmpty(t, actual)
+			}
+		})
+	}
 }
 
 func TestCopy(t *testing.T) {

--- a/aws/awss3/awss3_test.go
+++ b/aws/awss3/awss3_test.go
@@ -289,53 +289,9 @@ func TestPresign(t *testing.T) {
 func TestResponseContentDisposition(t *testing.T) {
 	const fileName = ",あいうえお　牡蠣喰家来 サシスセソ@+$_-^|+{}"
 	t.Run("success", func(t *testing.T) {
-		actual := awss3.ResponseContentDisposition(fileName)
+		actual := awss3.ResponseContentDisposition(s3presigned.ContentDispositionTypeAttachment, fileName)
 		assert.NotEmpty(t, actual)
 	})
-}
-
-func TestResponseContentDispositionMulti(t *testing.T) {
-	const fileName = ",あいうえお　牡蠣喰家来 サシスセソ@+$_-^|+{}"
-
-	cases := map[string]struct {
-		tp       s3presigned.ContentDispositionType
-		fileName string
-		emptyFLG bool
-	}{
-		"inline": {
-			fileName: "",
-			tp:       s3presigned.PresignFileTypeInline,
-		},
-		"inline&filename": {
-			tp:       s3presigned.PresignFileTypeInline,
-			fileName: fileName,
-		},
-		"attachment": {
-			tp:       s3presigned.PresignFileTypeAttachment,
-			fileName: "",
-		},
-		"attachment&filename": {
-			tp:       s3presigned.PresignFileTypeAttachment,
-			fileName: fileName,
-		},
-		"empty": {
-			tp:       "",
-			fileName: "",
-			emptyFLG: true,
-		},
-	}
-
-	for name, c := range cases {
-		t.Run(name, func(t *testing.T) {
-			actual := awss3.ResponseContentDispositionMulti(c.tp, c.fileName)
-			switch c.emptyFLG {
-			case true:
-				assert.Empty(t, actual)
-			default:
-				assert.NotEmpty(t, actual)
-			}
-		})
-	}
 }
 
 func TestCopy(t *testing.T) {

--- a/aws/awss3/options/s3presigned/s3_presigned.go
+++ b/aws/awss3/options/s3presigned/s3_presigned.go
@@ -10,7 +10,19 @@ type OptionS3Presigned interface {
 
 type confS3Presigned struct {
 	PresignFileName string
+	PresignFileType *ContentDispositionType // inline or attachment
 	PresignExpires  time.Duration
+}
+
+type ContentDispositionType string
+
+const (
+	PresignFileTypeInline     ContentDispositionType = "inline"
+	PresignFileTypeAttachment ContentDispositionType = "attachment"
+)
+
+func (o *ContentDispositionType) String() string {
+	return string(*o)
 }
 
 // nolint:revive
@@ -43,4 +55,15 @@ func (o OptionPresignExpires) Apply(c *confS3Presigned) {
 
 func WithPresignExpires(presignExpires time.Duration) OptionPresignExpires {
 	return OptionPresignExpires(presignExpires)
+}
+
+type OptionContentDispositionType ContentDispositionType
+
+func (o OptionContentDispositionType) Apply(c *confS3Presigned) {
+	cdtype := ContentDispositionType(o)
+	c.PresignFileType = &cdtype
+}
+
+func WithContentDispositionType(tp ContentDispositionType) OptionContentDispositionType {
+	return OptionContentDispositionType(tp)
 }

--- a/aws/awss3/options/s3presigned/s3_presigned.go
+++ b/aws/awss3/options/s3presigned/s3_presigned.go
@@ -9,21 +9,16 @@ type OptionS3Presigned interface {
 }
 
 type confS3Presigned struct {
-	PresignFileName string
-	PresignFileType *ContentDispositionType // inline or attachment
-	PresignExpires  time.Duration
+	ContentDispositionType ContentDispositionType
+	PresignExpires         time.Duration
+	PresignFileName        string
 }
-
-type ContentDispositionType string
+type ContentDispositionType int
 
 const (
-	PresignFileTypeInline     ContentDispositionType = "inline"
-	PresignFileTypeAttachment ContentDispositionType = "attachment"
+	ContentDispositionTypeAttachment ContentDispositionType = iota
+	ContentDispositionTypeInline
 )
-
-func (o *ContentDispositionType) String() string {
-	return string(*o)
-}
 
 // nolint:revive
 func GetS3PresignedConf(opts ...OptionS3Presigned) confS3Presigned {
@@ -60,8 +55,7 @@ func WithPresignExpires(presignExpires time.Duration) OptionPresignExpires {
 type OptionContentDispositionType ContentDispositionType
 
 func (o OptionContentDispositionType) Apply(c *confS3Presigned) {
-	cdtype := ContentDispositionType(o)
-	c.PresignFileType = &cdtype
+	c.ContentDispositionType = ContentDispositionType(o)
 }
 
 func WithContentDispositionType(tp ContentDispositionType) OptionContentDispositionType {


### PR DESCRIPTION
Fixes to allow detailed settings for ContentDisposition.

In order not to change the existing behavior, the new option is overwritten if it exists after the existing one.