### PR TITLE
chore: Fixed a bug that returned a response with `Content-Type: pdf` for PDF

### DIFF
--- a/aws/awss3/awss3.go
+++ b/aws/awss3/awss3.go
@@ -59,6 +59,10 @@ func (k Key) BucketJoinAWSString(bucketName BucketName) *string {
 	return aws.String(path.Join(bucketName.String(), k.String()))
 }
 
+func (k Key) Ext() string {
+	return strings.ToLower(filepath.Ext(string(k)))
+}
+
 type Keys []Key
 
 func NewKeys(keys ...string) Keys {
@@ -312,6 +316,11 @@ func Presign(ctx context.Context, region awsconfig.Region, bucketName BucketName
 	}
 	if c.PresignFileName != "" {
 		input.ResponseContentDisposition = aws.String(ResponseContentDisposition(c.ContentDispositionType, c.PresignFileName))
+	}
+	// Note: Fixed a bug in which the response is returned with `Content-Type:pdf` in case of PDF.
+	// convert to Content-Type: application/pdf.
+	if key.Ext() == ".pdf" {
+		input.ResponseContentType = aws.String("application/pdf")
 	}
 	ps := s3.NewPresignClient(client)
 	resp, err := ps.PresignGetObject(ctx, input, func(o *s3.PresignOptions) {


### PR DESCRIPTION
For PDF, the response is returned with Content-Type: pdf.
If it is not returned with Content-Type: application/pdf, the browser cannot identify it as a PDF, and the PDF cannot be opened in the browser.

# AsIs
```
HTTP/1.1 200 OK
x-amz-id-2: ****
x-amz-request-id: ****
Date: Wed, 22 Mar 2023 02:11:22 GMT
Last-Modified: Mon, 20 Mar 2023 10:01:35 GMT
ETag: "****"
x-amz-server-side-encryption: AES256
Content-Disposition: inline; filename*=UTF-8''test.pdf
Accept-Ranges: bytes
Content-Type: pdf
Server: AmazonS3
Content-Length: 77123
```

# Tobe
```
HTTP/1.1 200 OK
x-amz-id-2: ****
x-amz-request-id: ****
Date: Wed, 22 Mar 2023 02:11:22 GMT
Last-Modified: Mon, 20 Mar 2023 10:01:35 GMT
ETag: "****"
x-amz-server-side-encryption: AES256
Content-Disposition: inline; filename*=UTF-8''test.pdf
Accept-Ranges: bytes
Content-Type: application/pdf
Server: AmazonS3
Content-Length: 77123
```