### PR TITLE
Semgrep、Secretlintを実行するWorkflowの追加

### DIFF
--- a/.github/workflows/secretlint.yml
+++ b/.github/workflows/secretlint.yml
@@ -1,0 +1,39 @@
+# PR単位で差分があるファイルに対してSecretlint(シークレットスキャンツール)を実行し、
+# アクセストークンなど秘匿すべき値をPRコメントで指摘するワークフローです
+# 詳細は以下のドキュメントをご参照ください
+# https://andpad-dev.esa.io/posts/8984
+
+name: secretlint
+
+on:
+  pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secretlint:
+    name: secretlint
+    runs-on: ubuntu-latest
+    # Skip any PR created by dependabot to avoid permission issues
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - name: Check out code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0
+      - uses: reviewdog/action-setup@8e48baae926e97848f0863ae248f3b08e089c81f # v1.0.5
+      - id: changed-files
+        uses: tj-actions/changed-files@54849deb963ca9f24185fb5de2965e002d066e6b # v37.0.5
+      - name: Run secretlint
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker run \
+            -v $(pwd):/workdir \
+            -w /workdir \
+            secretlint/secretlint:v7.0.2@sha256:f0b1a4944a6a0f3d6a494c063b807ff6febc762f6fdf52466b2b8e3b278966d2 \
+            secretlint --format checkstyle ${{ steps.changed-files.outputs.all_changed_files }} \
+            | sed 's#="/workdir/#="#g' \
+            | reviewdog -f=checkstyle -reporter=github-pr-review -diff="git diff FETCH_HEAD"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,45 @@
+# PR単位で差分があるファイルに対してSemgrep(SASTツール)を実行し、
+# 脆弱性につながる可能性のある記述をPRコメントで指摘するワークフローです
+# 詳細は以下のドキュメントをご参照ください
+# https://andpad-dev.esa.io/posts/8984
+
+name: semgrep
+
+on:
+  pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: semgrep
+    runs-on: ubuntu-latest
+    # Skip any PR created by dependabot to avoid permission issues
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - name: Check out code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0
+      - uses: reviewdog/action-setup@8e48baae926e97848f0863ae248f3b08e089c81f # v1.0.5
+      - id: changed-files
+        uses: tj-actions/changed-files@54849deb963ca9f24185fb5de2965e002d066e6b # v37.0.5
+      - id: run-semgrep
+        name: Run semgrep
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker run \
+            -v $(pwd):/workdir \
+            --workdir /workdir \
+            returntocorp/semgrep:1.27.0@sha256:7026020ebb6c1aa477431a2ba550df3ae4d080822e391d03bb816eeac700a36b \
+            semgrep scan --config auto --severity WARNING --json ${{ steps.changed-files.outputs.all_changed_files }} \
+          | jq -r '.results[] | "\(.path):\(.start.line):\(.start.col): \(.extra.message)"' \
+          | sed 's#^/workdir/##' \
+          | reviewdog \
+            -efm="%f:%l:%c: %m" \
+            -diff="git diff FETCH_HEAD" \
+            -level=warning \
+            -reporter=github-pr-review


### PR DESCRIPTION
## 概要
88labsの全てのリポジトリにSAST、シークレットスキャンツールを導入し、最低限のガードレールを整備することを目的にセキュリティチームが作成したPRです。
詳細は以下のアナウンスをご参照ください。
https://88oct.slack.com/archives/CSV13Q51U/p1689057106826729

## やったこと
GitHub ActionsでSAST、シークレットスキャンを実行するワークフローを追加しています。
ワークフローの内容は、PRで差分のあったファイルに対してスキャンを実行し、問題が見つかった場合はPRコメントで指摘するというものです。
.github/workflowsディレクトリにsemgrep.yml、secretlint.ymlが既に存在する場合、そのワークフローの追加はスキップされます。

## お願いしたいこと
以下をご一読いただき、PRのマージ、クローズなどの対応をお願いします :pray:
https://andpad-dev.esa.io/posts/8984#%E3%81%BF%E3%81%AA%E3%81%95%E3%82%93%E3%81%AB%E3%81%8A%E9%A1%98%E3%81%84%E3%81%97%E3%81%9F%E3%81%84%E3%81%93%E3%81%A8-1

以下ドキュメントの内容の抜粋。
```
既に他のツールを使っている、使っていないに関係なく、セキュリティチームがPRを出すことのできるリポジトリ全てにPRを出す予定です。
各リポジトリでどのようなツールを使用しているか調べ上げるのは大変なためです。
そのため、以下のケースごとに必要な対応をお願いします。

- 既に使用中のツールがある場合
  - その旨PRにコメントしてクローズしてください
- まだツールは入れていないが、他に使用したいツールがある場合
  - その旨PRにコメントしてクローズしてください
  - 理由があって他のツールの導入に時間がかかりそうな場合、それまでの間は我々が追加するツールを使うことを検討してください
- Semgrepを利用しているが、独自定義したルールでのみスキャンをしている場合
  - 使用中のWorkflowに `--config auto` を追加して推奨ルールを追加することを検討してください
- Semgrep、Secretlintのいずれかだけ入れたい場合
  - 不要なWorkflowを削除した上で、マージしてください
- Semgrep、Secretlintは使いたいが、ルールの追加、削除などしたい場合
  - [SASTツールを活用しよう](https://andpad-dev.esa.io/posts/8795)を参考に設定してみましょう
  - 必要なコミットを積んでマージしてください
- Semgrep、Secretlintを使いたい場合
  - ありがとうございます。そのままマージしてください
```

semgrep.ymlの追加がスキップされたリポジトリでも独自に定義したルールでのみスキャンしている場合、推奨ルールによるスキャンを追加することをおすすめします。

## その他
不明点などあれば `@88labs/team-security` をメンションしてコメントしていただくか、`#dev_support_security` チャンネルで `@dev_sec` をメンションしてください :pray:

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖