### PR TITLE
ファイル削除のみの場合にSecretlintがエラーにならないように

### DIFF
--- a/.github/workflows/secretlint.yml
+++ b/.github/workflows/secretlint.yml
@@ -27,6 +27,7 @@ jobs:
       - id: changed-files
         uses: tj-actions/changed-files@920e7b9ae1d45913fc81f86c956fee89c77d2e5e # v37.5.0
       - name: Run secretlint
+        if: steps.changed-files.outputs.all_changed_files_count != '0'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -27,6 +27,7 @@ jobs:
       - id: changed-files
         uses: tj-actions/changed-files@920e7b9ae1d45913fc81f86c956fee89c77d2e5e # v37.5.0
       - id: run-semgrep
+        if: steps.changed-files.outputs.all_changed_files_count != '0'
         name: Run semgrep
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
以下でアナウンスしたSecretlintがエラーになる件の対応です。
https://88oct.slack.com/archives/CSV13Q51U/p1690360190573679

Secretlintに渡しているall_changed_filesには削除したファイルは入らず、対象のファイルが存在しないとSecretlintはエラーを返すことが原因でした。

## やったこと
all_changed_files_countが0件の場合、スキャンをスキップするようにしました。
all_changed_files_countにはall_changed_filesの件数が格納されています。
参考：https://github.com/tj-actions/changed-files#outputs

Semgrepは対象ファイルがなくてもエラーにはなりませんが、無駄にスキャンが走らないように同じ対応を入れています。

## 確認したこと
https://github.com/88labs/andpad-template-repo で先行して修正を入れ、動作確認をしています。
詳細は https://github.com/88labs/andpad-template-repo/pull/3 の確認したことをご参照ください。

---

*This change was executed automatically with [Shepherd](https://github.com/NerdWalletOSS/shepherd).* 💚🤖