### PR TITLE
feat: awss3 DownloadFiles use PooledBufferedWriterReadFromProvider

### DIFF
--- a/aws/awss3/awss3.go
+++ b/aws/awss3/awss3.go
@@ -287,7 +287,10 @@ func DownloadFiles(ctx context.Context, region awsconfig.Region, bucketName Buck
 	}
 
 	uniqKeys := keys.Unique()
-	downloader := manager.NewDownloader(client)
+	option := func(d *manager.Downloader) {
+		d.BufferProvider = manager.NewPooledBufferedWriterReadFromProvider(5 * 1024 * 1024)
+	}
+	downloader := manager.NewDownloader(client, option)
 	paths := make([]string, len(uniqKeys))
 
 	getFilePath := func(s3Key string) string {


### PR DESCRIPTION
DL速度安定化のためにBufferProviderを指定する。
サイズはPartSizeに合わせる。

```
DefaultDownloadPartSize=1024*1204*5
DefaultPartBodyMaxRetries=3
DefaultDownloadConcurrency=5
```

https://zenn.dev/ichigo_dev/articles/2ff2ae3ce02e2a5f15da