### PR TITLE
feat: fix awss3 client mock resolver

### DIFF
--- a/aws/awss3/client.go
+++ b/aws/awss3/client.go
@@ -6,19 +6,16 @@ import (
 	"encoding/gob"
 	"fmt"
 	"net"
-	"net/url"
 	"sync"
 
+	"github.com/88labs/go-utils/aws/awsconfig"
+	"github.com/88labs/go-utils/aws/awss3/options/global/s3dialer"
+	"github.com/88labs/go-utils/aws/ctxawslocal"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	smithyendpoints "github.com/aws/smithy-go/endpoints"
-
-	"github.com/88labs/go-utils/aws/awsconfig"
-	"github.com/88labs/go-utils/aws/awss3/options/global/s3dialer"
-	"github.com/88labs/go-utils/aws/ctxawslocal"
 )
 
 var (
@@ -70,47 +67,19 @@ func GetClient(ctx context.Context, region awsconfig.Region) (*s3.Client, error)
 	return s3.NewFromConfig(awsCfg), nil
 }
 
-type staticResolver struct{}
-
-// ResolveEndpoint
-// Local test mocks endpoints to connect to minio
-//
-// FIXME: EndpointResolverWithOptionsFunc substitutes staticResolver for endpoint mock
-func (*staticResolver) ResolveEndpoint(_ context.Context, p s3.EndpointParameters) (
-	smithyendpoints.Endpoint, error,
-) {
-	if customEndpoint != "" {
-		endpoint, err := url.Parse(customEndpoint)
-		if err != nil {
-			return smithyendpoints.Endpoint{}, fmt.Errorf("unable to parse endpoint, %w", err)
-		}
-		if p.Bucket != nil {
-			endpoint = endpoint.JoinPath(*p.Bucket)
-		}
-		// This value will be used as-is when making the request.
-		return smithyendpoints.Endpoint{
-			URI: *endpoint,
-		}, nil
-	}
-	return smithyendpoints.Endpoint{}, &aws.EndpointNotFoundError{}
-}
-
 func getClientLocal(ctx context.Context, localProfile LocalProfile) (*s3.Client, error) {
-	// FIXME: EndpointResolverWithOptionsFunc substitutes staticResolver for endpoint mock
-	//        because HostnameImmutable is not enabled. (github.com/aws/aws-sdk-go-v2/config v1.25.4)
-	// https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/endpoints/
-	//customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-	//	if service == s3.ServiceID {
-	//		return aws.Endpoint{
-	//			PartitionID:       "aws",
-	//			URL:               localProfile.Endpoint,
-	//			SigningRegion:     region,
-	//			HostnameImmutable: true,
-	//		}, nil
-	//	}
-	//	// returning EndpointNotFoundError will allow the service to fallback to it's default resolution
-	//	return aws.Endpoint{}, &aws.EndpointNotFoundError{}
-	//})
+	customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+		if service == s3.ServiceID {
+			return aws.Endpoint{
+				PartitionID:       "aws",
+				URL:               localProfile.Endpoint,
+				SigningRegion:     region,
+				HostnameImmutable: true,
+			}, nil
+		}
+		// returning EndpointNotFoundError will allow the service to fallback to it's default resolution
+		return aws.Endpoint{}, &aws.EndpointNotFoundError{}
+	})
 	awsHttpClient := awshttp.NewBuildableClient()
 	if GlobalDialer != nil {
 		awsHttpClient.WithDialerOptions(func(dialer *net.Dialer) {
@@ -127,7 +96,7 @@ func getClientLocal(ctx context.Context, localProfile LocalProfile) (*s3.Client,
 	}
 	awsCfg, err := awsConfig.LoadDefaultConfig(ctx,
 		awsConfig.WithHTTPClient(awsHttpClient),
-		//awsConfig.WithEndpointResolverWithOptions(customResolver),
+		awsConfig.WithEndpointResolverWithOptions(customResolver),
 		awsConfig.WithCredentialsProvider(credentials.StaticCredentialsProvider{
 			Value: aws.Credentials{
 				AccessKeyID:     localProfile.AccessKey,
@@ -140,9 +109,7 @@ func getClientLocal(ctx context.Context, localProfile LocalProfile) (*s3.Client,
 		return nil, fmt.Errorf("unable to load SDK config, %w", err)
 	}
 	customEndpoint = localProfile.Endpoint
-	return s3.NewFromConfig(awsCfg, func(o *s3.Options) {
-		o.EndpointResolverV2 = &staticResolver{}
-	}), nil
+	return s3.NewFromConfig(awsCfg), nil
 }
 
 type LocalProfile struct {


### PR DESCRIPTION
As of v1.25.4, there was a bug in the s3 client that prevented the mock resolver from working properly
https://github.com/aws/aws-sdk-go-v2/issues/2395