### PR TITLE
fix: awss3 SelectCSVHeaders ignore ScanRange

### DIFF
--- a/aws/awss3/awss3.go
+++ b/aws/awss3/awss3.go
@@ -610,7 +610,6 @@ func SelectCSVHeaders(ctx context.Context, region awsconfig.Region, bucketName B
 		QuoteEscapeCharacter:       c.CSVInput.QuoteEscapeCharacter,
 		RecordDelimiter:            c.CSVInput.RecordDelimiter,
 	}))
-	opts = append(opts, s3selectcsv.WithSkipByteSize(0))
 	var buf bytes.Buffer
 	if err := SelectCSVAll(ctx, region, bucketName, key, SelectCSVLimit1Query, &buf, opts...); err != nil {
 		return nil, err


### PR DESCRIPTION
Cannot be used in combination with ScanRange and CSV + AllowQuotedRecordDelimiter

```
UnsupportedScanRangeInput: Scan range queries are not supported on objects with type CSV + AllowQuotedRecordDelimiter.
```