### PR TITLE
test-aws flaky retry=3

### DIFF
--- a/.github/workflows/test-aws.yaml
+++ b/.github/workflows/test-aws.yaml
@@ -27,7 +27,7 @@ jobs:
         go-version: [ 1.21.x ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
         run: |
           go install gotest.tools/gotestsum@latest
           # shellcheck disable=SC2046
-          gotestsum --junitfile unit-tests.xml -- -p 4 -parallel 4 -v ./... -race -coverprofile="coverage.txt" -covermode=atomic -coverpkg=./...
+          gotestsum --rerun-fails=3 --junitfile unit-tests.xml -- -p 4 -parallel 4 -v ./... -race -coverprofile="coverage.txt" -covermode=atomic -coverpkg=./...
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Change the aws sdk related tests to be able to run a certain number of tests as they are often flaky.

ref.
https://pkg.go.dev/gotest.tools/gotestsum#readme-re-running-failed-tests