### PR TITLE
Replace github.actor with github.event.pull_request.user.login

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
 
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
## 概要
`github.actor` は細工をすることで詐称でき、auto mergeなどしている場合に悪意のあるコードをマージさせる脆弱性があることがわかりました。
https://www.synacktiv.com/publications/github-actions-exploitation-dependabot

https://github.com/dependabot/fetch-metadata を使用している場合はこの影響を受けません。
このワークフロー内でのチェックにより詐称されている場合は落ちるためです。
そのため現状では影響を受けませんが、より安全な記述に置き換えることで攻撃を受ける可能性を減らします。

## やったこと
`github.actor` を `github.event.pull_request.user.login` に置き換えました。
[README](https://github.com/dependabot/fetch-metadata?tab=readme-ov-file#enabling-auto-merge)でもこの記述が使われています。

