### PR TITLE
envlookup: Go1.24, Add LookUpStringSlice, Add LookUpDuration, Changed interface design to return errors instead of panics, added Must function.

### DIFF
--- a/envlookup/envlookup.go
+++ b/envlookup/envlookup.go
@@ -4,65 +4,125 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/88labs/go-utils/aws/awsconfig"
 )
 
-func LookUpString(env string, required bool) string {
-	if v, ok := os.LookupEnv(env); ok {
-		return v
-	}
-	if required {
-		panic(fmt.Errorf("environment variable is not set to %s", env))
-	}
-	return ""
-}
-
-func LookUpInt(env string) int {
-	if envValue, ok := os.LookupEnv(env); ok {
-		if v, err := strconv.Atoi(envValue); err != nil {
-			panic(err)
-		} else {
-			return v
-		}
-	}
-	panic(fmt.Errorf("environment variable is not set to %s", env))
-}
-
-func LookUpTime(env string) time.Time {
-	if envValue, ok := os.LookupEnv(env); ok {
-		if v, err := time.Parse(time.RFC3339, envValue); err != nil {
-			panic(err)
-		} else {
-			return v
-		}
-	}
-	panic(fmt.Errorf("environment variable is not set to %s", env))
-}
-
-func LookUpRegion(env string) awsconfig.Region {
-	v := LookUpString(env, true)
-	region, err := awsconfig.ParseRegion(v)
+func Must[T any](v T, err error) T {
 	if err != nil {
 		panic(err)
 	}
-	return region
+	return v
 }
 
-func LookUpBool(env string, required bool) bool {
+// LookUpString
+// Read values from environment variables with string
+// required: If true, panic if the environment variable is not set
+func LookUpString(env string, required bool) (string, error) {
+	if v, ok := os.LookupEnv(env); ok {
+		return v, nil
+	}
+	if required {
+		return "", fmt.Errorf("environment variable is not set to %s", env)
+	}
+	return "", nil
+}
+
+// LookUpStringSlice
+// Read values from environment variables with []string
+// sep: Separator
+// required: If true, panic if the environment variable is not set
+func LookUpStringSlice(env string, sep string, required bool) ([]string, error) {
+	if v, ok := os.LookupEnv(env); ok {
+		return strings.Split(v, sep), nil
+	}
+	if required {
+		return nil, fmt.Errorf("environment variable is not set to %s", env)
+	}
+	return []string(nil), nil
+}
+
+// LookUpInt
+// Read values from environment variables with int
+// required: If true, panic if the environment variable is not set
+func LookUpInt(env string, required bool) (int, error) {
+	if envValue, ok := os.LookupEnv(env); ok {
+		if v, err := strconv.Atoi(envValue); err != nil {
+			return 0, err
+		} else {
+			return v, nil
+		}
+	}
+	if required {
+		return 0, fmt.Errorf("environment variable is not set to %s", env)
+	}
+	return 0, nil
+}
+
+// LookUpTime
+// Read values from environment variables with time.Time
+// required: If true, panic if the environment variable is not set
+func LookUpTime(env string, required bool) (time.Time, error) {
+	if envValue, ok := os.LookupEnv(env); ok {
+		if v, err := time.Parse(time.RFC3339, envValue); err != nil {
+			return time.Time{}, err
+		} else {
+			return v, nil
+		}
+	}
+	if required {
+		return time.Time{}, fmt.Errorf("environment variable is not set to %s", env)
+	}
+	return time.Time{}, nil
+}
+
+// LookUpDuration
+// Read values from environment variables with time.Duration
+// required: If true, panic if the environment variable is not set
+func LookUpDuration(env string, required bool) (time.Duration, error) {
+	if envValue, ok := os.LookupEnv(env); ok {
+		if v, err := time.ParseDuration(envValue); err != nil {
+			return 0, err
+		} else {
+			return v, nil
+		}
+	}
+	if required {
+		return 0, fmt.Errorf("environment variable is not set to %s", env)
+	}
+	return 0, nil
+}
+
+// LookUpRegion
+// Read values from environment variables with awsconfig.Region
+// required: If true, panic if the environment variable is not set
+func LookUpRegion(env string, required bool) (awsconfig.Region, error) {
+	v, err := LookUpString(env, required)
+	if err != nil {
+		return "", err
+	}
+	region, err := awsconfig.ParseRegion(v)
+	if err != nil {
+		return "", err
+	}
+	return region, nil
+}
+
+// LookUpBool
+// Read values from environment variables with bool
+// required: If true, panic if the environment variable is not set
+func LookUpBool(env string, required bool) (bool, error) {
 	if v, ok := os.LookupEnv(env); ok {
 		b, err := strconv.ParseBool(v)
 		if err != nil {
-			if required {
-				panic(fmt.Errorf("environment variable is not set to %s %s", env, err.Error()))
-			}
-			return false
+			return false, fmt.Errorf("environment variable is not set to %s %s", env, err.Error())
 		}
-		return b
+		return b, nil
 	}
 	if required {
-		panic(fmt.Errorf("environment variable is not set to %s", env))
+		return false, fmt.Errorf("environment variable is not set to %s", env)
 	}
-	return false
+	return false, nil
 }

--- a/envlookup/envlookup_test.go
+++ b/envlookup/envlookup_test.go
@@ -1,13 +1,15 @@
 package envlookup_test
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/88labs/go-utils/aws/awsconfig"
 	"github.com/go-faker/faker/v4"
-	"github.com/stretchr/testify/assert"
+	"gotest.tools/assert"
 
+	"github.com/88labs/go-utils/aws/awsconfig"
 	"github.com/88labs/go-utils/envlookup"
 )
 
@@ -18,7 +20,7 @@ func TestLookUpString(t *testing.T) {
 	}
 	type Want struct {
 		Val string
-		Err bool
+		Err error
 	}
 	tests := map[string]struct {
 		SetEnv func(t *testing.T) (Param, Want)
@@ -33,7 +35,7 @@ func TestLookUpString(t *testing.T) {
 						Required: true,
 					}, Want{
 						Val: val,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -46,7 +48,7 @@ func TestLookUpString(t *testing.T) {
 						Key:      "NOT_EXIST",
 						Required: true,
 					}, Want{
-						Err: true,
+						Err: errors.New("environment variable is not set to " + "NOT_EXIST"),
 					}
 			},
 		},
@@ -60,7 +62,7 @@ func TestLookUpString(t *testing.T) {
 						Required: false,
 					}, Want{
 						Val: val,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -74,36 +76,126 @@ func TestLookUpString(t *testing.T) {
 						Required: false,
 					}, Want{
 						Val: "",
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
 	}
 
-	for n, v := range tests {
-		name := n
-		tt := v
+	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			p, want := tt.SetEnv(t)
-			if want.Err {
-				assert.Panics(t, func() {
-					envlookup.LookUpString(p.Key, p.Required)
-				})
+			got, err := envlookup.LookUpString(p.Key, p.Required)
+			if want.Err != nil {
+				assert.Error(t, err, want.Err.Error())
 				return
 			}
-			got := envlookup.LookUpString(p.Key, p.Required)
+			assert.NilError(t, err)
 			assert.Equal(t, want.Val, got)
+		})
+	}
+}
+
+func TestLookUpStringSlice(t *testing.T) {
+	type Param struct {
+		Key      string
+		Sep      string
+		Required bool
+	}
+	type Want struct {
+		Val []string
+		Err error
+	}
+	tests := map[string]struct {
+		SetEnv func(t *testing.T) (Param, Want)
+	}{
+		"required:key exists": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val1 := faker.Sentence()
+				val2 := faker.Sentence()
+				t.Setenv(key, strings.Join([]string{val1, val2}, ","))
+				return Param{
+						Key:      key,
+						Sep:      ",",
+						Required: true,
+					}, Want{
+						Val: []string{val1, val2},
+						Err: nil,
+					}
+			},
+		},
+		"required:sep:|": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val1 := faker.Sentence()
+				val2 := faker.Sentence()
+				t.Setenv(key, strings.Join([]string{val1, val2}, "|"))
+				return Param{
+						Key:      key,
+						Sep:      "|",
+						Required: true,
+					}, Want{
+						Val: []string{val1, val2},
+						Err: nil,
+					}
+			},
+		},
+		"required:key not exists": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val1 := faker.Sentence()
+				val2 := faker.Sentence()
+				t.Setenv(key, strings.Join([]string{val1, val2}, ","))
+				return Param{
+						Key:      "NOT_EXIST",
+						Sep:      ",",
+						Required: true,
+					}, Want{
+						Err: errors.New("environment variable is not set to " + "NOT_EXIST"),
+					}
+			},
+		},
+		"not required:key exists": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val1 := faker.Sentence()
+				val2 := faker.Sentence()
+				t.Setenv(key, strings.Join([]string{val1, val2}, ","))
+				return Param{
+						Key:      "NOT_EXIST",
+						Sep:      ",",
+						Required: false,
+					}, Want{
+						Val: []string(nil),
+						Err: nil,
+					}
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			p, want := tt.SetEnv(t)
+			got, err := envlookup.LookUpStringSlice(p.Key, p.Sep, p.Required)
+			if want.Err != nil {
+				assert.Error(t, err, want.Err.Error())
+				return
+			}
+			assert.NilError(t, err)
+			assert.DeepEqual(t, want.Val, got)
 		})
 	}
 }
 
 func TestLookUpInt(t *testing.T) {
 	type Param struct {
-		Key string
+		Key      string
+		Required bool
 	}
 	type Want struct {
 		Val int
-		Err bool
+		Err error
 	}
 	tests := map[string]struct {
 		SetEnv func(t *testing.T) (Param, Want)
@@ -114,10 +206,11 @@ func TestLookUpInt(t *testing.T) {
 				val := "1"
 				t.Setenv(key, val)
 				return Param{
-						Key: key,
+						Key:      key,
+						Required: true,
 					}, Want{
 						Val: 1,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -127,10 +220,11 @@ func TestLookUpInt(t *testing.T) {
 				val := "0"
 				t.Setenv(key, val)
 				return Param{
-						Key: key,
+						Key:      key,
+						Required: true,
 					}, Want{
 						Val: 0,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -140,38 +234,51 @@ func TestLookUpInt(t *testing.T) {
 				val := "hoge"
 				t.Setenv(key, val)
 				return Param{
-						Key: key,
+						Key:      key,
+						Required: true,
 					}, Want{
-						Err: true,
+						Err: errors.New(`strconv.Atoi: parsing "` + val + `": invalid syntax`),
 					}
 			},
 		},
-		"key not exists": {
+		"not required:key not exists": {
 			SetEnv: func(t *testing.T) (Param, Want) {
 				key := faker.UUIDHyphenated()
 				val := "1"
 				t.Setenv(key, val)
 				return Param{
-						Key: "NOT_EXIST",
+						Key:      "NOT_EXIST",
+						Required: false,
 					}, Want{
-						Err: true,
+						Val: 0,
+						Err: nil,
+					}
+			},
+		},
+		"required:key not exists": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val := "1"
+				t.Setenv(key, val)
+				return Param{
+						Key:      "NOT_EXIST",
+						Required: true,
+					}, Want{
+						Err: errors.New("environment variable is not set to " + "NOT_EXIST"),
 					}
 			},
 		},
 	}
 
-	for n, v := range tests {
-		name := n
-		tt := v
+	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			p, want := tt.SetEnv(t)
-			if want.Err {
-				assert.Panics(t, func() {
-					envlookup.LookUpInt(p.Key)
-				})
+			got, err := envlookup.LookUpInt(p.Key, p.Required)
+			if want.Err != nil {
+				assert.Error(t, err, want.Err.Error())
 				return
 			}
-			got := envlookup.LookUpInt(p.Key)
+			assert.NilError(t, err)
 			assert.Equal(t, want.Val, got)
 		})
 	}
@@ -179,11 +286,12 @@ func TestLookUpInt(t *testing.T) {
 
 func TestLookUpTime(t *testing.T) {
 	type Param struct {
-		Key string
+		Key      string
+		Required bool
 	}
 	type Want struct {
 		Val time.Time
-		Err bool
+		Err error
 	}
 	tests := map[string]struct {
 		SetEnv func(t *testing.T) (Param, Want)
@@ -194,10 +302,11 @@ func TestLookUpTime(t *testing.T) {
 				val := "2022-01-02T03:04:05Z"
 				t.Setenv(key, val)
 				return Param{
-						Key: key,
+						Key:      key,
+						Required: true,
 					}, Want{
 						Val: time.Date(2022, 1, 2, 3, 4, 5, 0, time.UTC),
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -207,9 +316,10 @@ func TestLookUpTime(t *testing.T) {
 				val := "2022-01-02"
 				t.Setenv(key, val)
 				return Param{
-						Key: key,
+						Key:      key,
+						Required: true,
 					}, Want{
-						Err: true,
+						Err: errors.New(`parsing time "` + val + `" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "T"`),
 					}
 			},
 		},
@@ -219,38 +329,147 @@ func TestLookUpTime(t *testing.T) {
 				val := "hoge"
 				t.Setenv(key, val)
 				return Param{
-						Key: key,
+						Key:      key,
+						Required: true,
 					}, Want{
-						Err: true,
+						Err: errors.New(`parsing time "` + val + `" as "2006-01-02T15:04:05Z07:00": cannot parse "hoge" as "2006"`),
 					}
 			},
 		},
-		"key not exists": {
+		"not required:key not exists": {
 			SetEnv: func(t *testing.T) (Param, Want) {
 				key := faker.UUIDHyphenated()
 				val := faker.Sentence()
 				t.Setenv(key, val)
 				return Param{
-						Key: "NOT_EXIST",
+						Key:      "NOT_EXIST",
+						Required: false,
 					}, Want{
-						Err: true,
+						Val: time.Time{},
+						Err: nil,
+					}
+			},
+		},
+		"required:key not exists": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val := faker.Sentence()
+				t.Setenv(key, val)
+				return Param{
+						Key:      "NOT_EXIST",
+						Required: true,
+					}, Want{
+						Err: errors.New("environment variable is not set to " + "NOT_EXIST"),
 					}
 			},
 		},
 	}
 
-	for n, v := range tests {
-		name := n
-		tt := v
+	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			p, want := tt.SetEnv(t)
-			if want.Err {
-				assert.Panics(t, func() {
-					envlookup.LookUpTime(p.Key)
-				})
+			got, err := envlookup.LookUpTime(p.Key, p.Required)
+			if want.Err != nil {
+				assert.Error(t, err, want.Err.Error())
 				return
 			}
-			got := envlookup.LookUpTime(p.Key)
+			assert.NilError(t, err)
+			assert.Equal(t, want.Val, got)
+		})
+	}
+}
+
+func TestLookUpDuration(t *testing.T) {
+	type Param struct {
+		Key      string
+		Required bool
+	}
+	type Want struct {
+		Val time.Duration
+		Err error
+	}
+	tests := map[string]struct {
+		SetEnv func(t *testing.T) (Param, Want)
+	}{
+		"key exists:10s": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val := "10s"
+				t.Setenv(key, val)
+				return Param{
+						Key:      key,
+						Required: true,
+					}, Want{
+						Val: 10 * time.Second,
+						Err: nil,
+					}
+			},
+		},
+		"key exists:30m": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val := "30m"
+				t.Setenv(key, val)
+				return Param{
+						Key:      key,
+						Required: true,
+					}, Want{
+						Val: 30 * time.Minute,
+						Err: nil,
+					}
+			},
+		},
+		"key exists:not Duration": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val := "hoge"
+				t.Setenv(key, val)
+				return Param{
+						Key:      key,
+						Required: true,
+					}, Want{
+						Err: errors.New(`time: invalid duration "` + val + `"`),
+					}
+			},
+		},
+		"not required:key not exists": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val := faker.Sentence()
+				t.Setenv(key, val)
+				return Param{
+						Key:      "NOT_EXIST",
+						Required: false,
+					}, Want{
+						Val: 0,
+						Err: nil,
+					}
+			},
+		},
+		"required:key not exists": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val := faker.Sentence()
+				t.Setenv(key, val)
+				return Param{
+						Key:      "NOT_EXIST",
+						Required: true,
+					}, Want{
+						Err: errors.New("environment variable is not set to " + "NOT_EXIST"),
+					}
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			p, want := tt.SetEnv(t)
+			got, err := envlookup.LookUpDuration(p.Key, p.Required)
+			if want.Err != nil {
+				assert.Error(t, err, want.Err.Error())
+				return
+			}
+			assert.NilError(t, err)
 			assert.Equal(t, want.Val, got)
 		})
 	}
@@ -258,11 +477,12 @@ func TestLookUpTime(t *testing.T) {
 
 func TestLookUpRegion(t *testing.T) {
 	type Param struct {
-		Key string
+		Key      string
+		Required bool
 	}
 	type Want struct {
 		Val awsconfig.Region
-		Err bool
+		Err error
 	}
 	tests := map[string]struct {
 		SetEnv func(t *testing.T) (Param, Want)
@@ -273,10 +493,11 @@ func TestLookUpRegion(t *testing.T) {
 				val := awsconfig.RegionOhio
 				t.Setenv(key, val.String())
 				return Param{
-						Key: key,
+						Key:      key,
+						Required: true,
 					}, Want{
 						Val: val,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -286,38 +507,50 @@ func TestLookUpRegion(t *testing.T) {
 				val := "hoge"
 				t.Setenv(key, val)
 				return Param{
-						Key: key,
+						Key:      key,
+						Required: true,
 					}, Want{
-						Err: true,
+						Err: errors.New("no supported region [" + val + "]"),
 					}
 			},
 		},
-		"key not exists": {
+		"not required:key not exists": {
 			SetEnv: func(t *testing.T) (Param, Want) {
 				key := faker.UUIDHyphenated()
 				val := awsconfig.RegionOhio
 				t.Setenv(key, val.String())
 				return Param{
-						Key: "NOT_EXIST",
+						Key:      "NOT_EXIST",
+						Required: false,
 					}, Want{
-						Err: true,
+						Err: errors.New("no supported region []"),
+					}
+			},
+		},
+		"required:key not exists": {
+			SetEnv: func(t *testing.T) (Param, Want) {
+				key := faker.UUIDHyphenated()
+				val := awsconfig.RegionOhio
+				t.Setenv(key, val.String())
+				return Param{
+						Key:      "NOT_EXIST",
+						Required: true,
+					}, Want{
+						Err: errors.New("environment variable is not set to " + "NOT_EXIST"),
 					}
 			},
 		},
 	}
 
-	for n, v := range tests {
-		name := n
-		tt := v
+	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			p, want := tt.SetEnv(t)
-			if want.Err {
-				assert.Panics(t, func() {
-					envlookup.LookUpRegion(p.Key)
-				})
+			got, err := envlookup.LookUpRegion(p.Key, p.Required)
+			if want.Err != nil {
+				assert.Error(t, err, want.Err.Error())
 				return
 			}
-			got := envlookup.LookUpRegion(p.Key)
+			assert.NilError(t, err)
 			assert.Equal(t, want.Val, got)
 		})
 	}
@@ -330,7 +563,7 @@ func TestLookUpBool(t *testing.T) {
 	}
 	type Want struct {
 		Val bool
-		Err bool
+		Err error
 	}
 	tests := map[string]struct {
 		SetEnv func(t *testing.T) (Param, Want)
@@ -345,7 +578,7 @@ func TestLookUpBool(t *testing.T) {
 						Required: true,
 					}, Want{
 						Val: true,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -359,7 +592,7 @@ func TestLookUpBool(t *testing.T) {
 						Required: true,
 					}, Want{
 						Val: false,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -373,7 +606,7 @@ func TestLookUpBool(t *testing.T) {
 						Required: true,
 					}, Want{
 						Val: true,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -387,7 +620,7 @@ func TestLookUpBool(t *testing.T) {
 						Required: true,
 					}, Want{
 						Val: false,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -400,7 +633,7 @@ func TestLookUpBool(t *testing.T) {
 						Key:      key,
 						Required: true,
 					}, Want{
-						Err: true,
+						Err: errors.New("environment variable is not set to " + key + " strconv.ParseBool: parsing \"" + val + "\": invalid syntax"),
 					}
 			},
 		},
@@ -414,7 +647,7 @@ func TestLookUpBool(t *testing.T) {
 						Required: true,
 					}, Want{
 						Val: true,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -427,7 +660,7 @@ func TestLookUpBool(t *testing.T) {
 						Key:      key,
 						Required: true,
 					}, Want{
-						Err: true,
+						Err: errors.New("environment variable is not set to " + key + " strconv.ParseBool: parsing \"" + val + "\": invalid syntax"),
 					}
 			},
 		},
@@ -440,7 +673,7 @@ func TestLookUpBool(t *testing.T) {
 						Key:      "NOT_EXIST",
 						Required: true,
 					}, Want{
-						Err: true,
+						Err: errors.New("environment variable is not set to NOT_EXIST"),
 					}
 			},
 		},
@@ -454,7 +687,7 @@ func TestLookUpBool(t *testing.T) {
 						Required: false,
 					}, Want{
 						Val: true,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
@@ -468,7 +701,7 @@ func TestLookUpBool(t *testing.T) {
 						Required: false,
 					}, Want{
 						Val: false,
-						Err: false,
+						Err: errors.New("environment variable is not set to " + key + " strconv.ParseBool: parsing \"" + val + "\": invalid syntax"),
 					}
 			},
 		},
@@ -482,24 +715,21 @@ func TestLookUpBool(t *testing.T) {
 						Required: false,
 					}, Want{
 						Val: false,
-						Err: false,
+						Err: nil,
 					}
 			},
 		},
 	}
 
-	for n, v := range tests {
-		name := n
-		tt := v
+	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			p, want := tt.SetEnv(t)
-			if want.Err {
-				assert.Panics(t, func() {
-					envlookup.LookUpBool(p.Key, p.Required)
-				})
+			got, err := envlookup.LookUpBool(p.Key, p.Required)
+			if want.Err != nil {
+				assert.Error(t, err, want.Err.Error())
 				return
 			}
-			got := envlookup.LookUpBool(p.Key, p.Required)
+			assert.NilError(t, err)
 			assert.Equal(t, want.Val, got)
 		})
 	}

--- a/envlookup/go.mod
+++ b/envlookup/go.mod
@@ -1,6 +1,6 @@
 module github.com/88labs/go-utils/envlookup
 
-go 1.23
+go 1.24
 
 require (
 	github.com/88labs/go-utils/aws v0.137.0
@@ -10,8 +10,11 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/envlookup/go.sum
+++ b/envlookup/go.sum
@@ -5,10 +5,14 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-faker/faker/v4 v4.6.0 h1:6aOPzNptRiDwD14HuAnEtlTa+D1IfFuEHO8+vEFwjTs=
 github.com/go-faker/faker/v4 v4.6.0/go.mod h1:ZmrHuVtTTm2Em9e0Du6CJ9CADaLEzGXW62z1YqFH0m0=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
@@ -22,3 +26,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=


### PR DESCRIPTION
`envlookup` was designed to always panic, even when it should not panic.
Change the function to return an error, and if it is acceptable to use panic, modify the function to wrap it with the `Must` function.

- Change
  - all function `return value, err`
  - Go 1.24
- Add
  - LookUpStringSlice
  - LookUpDuration
