### PR TITLE
[Security]Specify a commit hash for GHA's external actions

### DIFF
--- a/.github/workflows/auto_assign.yaml
+++ b/.github/workflows/auto_assign.yaml
@@ -7,6 +7,6 @@ jobs:
   add-reviews:
     runs-on: ubuntu-22.04
     steps:
-      - uses: kentaro-m/auto-assign-action@v2.0.0
+      - uses: kentaro-m/auto-assign-action@f4648c0a9fdb753479e9e75fc251f507ce17bb7e # v2.0.0
         with:
           configuration-path: '.github/auto_assign_configs.yaml'

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,8 +20,8 @@ jobs:
       #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         with:
           filters: |
@@ -49,7 +49,7 @@ jobs:
               - 'utf8bom/**'
             hashutil:
               - 'hashutil/**'
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.aws == 'true'
         with:
           config-name: release-drafter-aws.yml
@@ -58,7 +58,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.cerrors == 'true'
         with:
           config-name: release-drafter-cerrors.yml
@@ -67,7 +67,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.emailvalidator == 'true'
         with:
           config-name: release-drafter-emailvalidator.yml
@@ -76,7 +76,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.envlookup == 'true'
         with:
           config-name: release-drafter-envlookup.yml
@@ -85,7 +85,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.errgroup == 'true'
         with:
           config-name: release-drafter-errgroup.yml
@@ -94,7 +94,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.osext == 'true'
         with:
           config-name: release-drafter-osext.yml
@@ -103,7 +103,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.sentryhelper == 'true'
         with:
           config-name: release-drafter-sentryhelper.yml
@@ -112,7 +112,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.sql-escape == 'true'
         with:
           config-name: release-drafter-sql-escape.yml
@@ -121,7 +121,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.tspb_cast == 'true'
         with:
           config-name: release-drafter-tspb_cast.yml
@@ -130,7 +130,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.ulid == 'true'
         with:
           config-name: release-drafter-ulid.yml
@@ -139,7 +139,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.utf8bom == 'true'
         with:
           config-name: release-drafter-utf8bom.yml
@@ -148,7 +148,7 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
         if: steps.changes.outputs.hashutil == 'true'
         with:
           config-name: release-drafter-hashutil.yml

--- a/.github/workflows/secretlint.yml
+++ b/.github/workflows/secretlint.yml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/checkout@v4 # v3.5.3
         with:
           fetch-depth: 0
-      - uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0
+      - uses: reviewdog/action-setup@bddaa4f8db3717aad1ce0987da12e1cb4bd081c1 # v1.3.1
       - id: changed-files
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
       - name: Run secretlint
         if: steps.changed-files.outputs.all_changed_files_count != '0'
         env:
@@ -34,7 +34,7 @@ jobs:
           docker run \
             -v $(pwd):/workdir \
             -w /workdir \
-            secretlint/secretlint:v7.0.2@sha256:f0b1a4944a6a0f3d6a494c063b807ff6febc762f6fdf52466b2b8e3b278966d2 \
+            secretlint/secretlint:v9.2.0@sha256:ab6638799087b65bb044d08143e3f950467ca8905cea582a5911578b2026f5b6 \
             secretlint --format checkstyle ${{ steps.changed-files.outputs.all_changed_files }} \
             | sed 's#="/workdir/#="#g' \
             | reviewdog -f=checkstyle -reporter=github-pr-review -diff="git diff FETCH_HEAD"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/checkout@v4 # v3.5.3
         with:
           fetch-depth: 0
-      - uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0
+      - uses: reviewdog/action-setup@bddaa4f8db3717aad1ce0987da12e1cb4bd081c1 # v1.3.1
       - id: changed-files
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
       - id: run-semgrep
         if: steps.changed-files.outputs.all_changed_files_count != '0'
         name: Run semgrep
@@ -35,7 +35,7 @@ jobs:
           docker run \
             -v $(pwd):/workdir \
             --workdir /workdir \
-            returntocorp/semgrep:1.27.0@sha256:7026020ebb6c1aa477431a2ba550df3ae4d080822e391d03bb816eeac700a36b \
+            semgrep/semgrep:pro-sha-511dd7ce3c1b7f2f35a4bf9422d3f81ffbe2a688@sha256:fdd6eb7b18182d42817b4dc7ab7112856d2a6183f019de9e32dda0cf022eb575 \
             semgrep scan --config auto --severity WARNING --json ${{ steps.changed-files.outputs.all_changed_files }} \
           | jq -r '.results[] | "\(.path):\(.start.line):\(.start.col): \(.extra.message)"' \
           | sed 's#^/workdir/##' \

--- a/.github/workflows/test-aws.yaml
+++ b/.github/workflows/test-aws.yaml
@@ -54,13 +54,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ matrix.go-version }}
           cache-dependency-path: |
             ${{ env.testdir }}/go.sum
       - id: install-minio-cli
-        uses: yakubique/setup-minio-cli@d9826c1ad14228495203415557139d4cf491bed9 # v1.0.0
+        uses: yakubique/setup-minio-cli@d9826c1ad14228495203415557139d4cf491bed9 # v1
       - name: Setup gotestsum
         uses: autero1/action-gotestsum@7263b9d73912eec65f46337689e59fac865c425f # v2.0.0
         with:
@@ -100,7 +100,7 @@ jobs:
           # shellcheck disable=SC2046
           # FIXME: awsdynamo test doesn't work with ci.
           gotestsum --format testname --junitfile unit-tests.xml -- -p 4 -race -coverprofile="coverage.txt" -covermode=atomic -coverpkg=./... $(go list ./... | grep -v awsdynamo)
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./unit-tests.xml,./coverage.txt

--- a/.github/workflows/test-cerrors.yaml
+++ b/.github/workflows/test-cerrors.yaml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Go Module Download
         working-directory: ${{ env.testdir }}
@@ -46,7 +46,7 @@ jobs:
           # shellcheck disable=SC2046
           gotestsum --junitfile unit-tests.xml -- -v ./... -race -coverprofile="coverage.txt" -covermode=atomic -coverpkg=./...
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.testdir }}/coverage.txt

--- a/.github/workflows/test-emailvalidator.yaml
+++ b/.github/workflows/test-emailvalidator.yaml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Go Module Download
         working-directory: ${{ env.testdir }}
@@ -46,7 +46,7 @@ jobs:
           # shellcheck disable=SC2046
           gotestsum --junitfile unit-tests.xml -- -v ./... -race -coverprofile="coverage.txt" -covermode=atomic -coverpkg=./...
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.testdir }}/coverage.txt

--- a/.github/workflows/test-envlookup.yaml
+++ b/.github/workflows/test-envlookup.yaml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Go Module Download
         working-directory: ${{ env.testdir }}
@@ -46,7 +46,7 @@ jobs:
           # shellcheck disable=SC2046
           gotestsum --junitfile unit-tests.xml -- -v ./... -race -coverprofile="coverage.txt" -covermode=atomic -coverpkg=./...
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.testdir }}/coverage.txt

--- a/.github/workflows/test-hashutil.yaml
+++ b/.github/workflows/test-hashutil.yaml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Go Module Download
         working-directory: ${{ env.testdir }}
@@ -46,7 +46,7 @@ jobs:
           # shellcheck disable=SC2046
           gotestsum --junitfile unit-tests.xml -- -v ./... -race -coverprofile="coverage.txt" -covermode=atomic -coverpkg=./...
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.testdir }}/coverage.txt

--- a/.github/workflows/test-ulid.yaml
+++ b/.github/workflows/test-ulid.yaml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Go Module Download
         working-directory: ${{ env.testdir }}
@@ -46,7 +46,7 @@ jobs:
           # shellcheck disable=SC2046
           gotestsum --junitfile unit-tests.xml -- -v ./... -race -coverprofile="coverage.txt" -covermode=atomic -coverpkg=./...
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.testdir }}/coverage.txt

--- a/.github/workflows/test-utf8bom.yaml
+++ b/.github/workflows/test-utf8bom.yaml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Go Module Download
         working-directory: ${{ env.testdir }}
@@ -46,7 +46,7 @@ jobs:
           # shellcheck disable=SC2046
           gotestsum --junitfile unit-tests.xml -- -v ./... -race -coverprofile="coverage.txt" -covermode=atomic -coverpkg=./...
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.testdir }}/coverage.txt

--- a/aws/go.mod
+++ b/aws/go.mod
@@ -1,6 +1,7 @@
 module github.com/88labs/go-utils/aws
 
-go 1.23
+go 1.23.0
+
 toolchain go1.24.1
 
 require (

--- a/aws/go.mod
+++ b/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/88labs/go-utils/aws
 
-go 1.23.0
+go 1.24
 
 toolchain go1.24.1
 


### PR DESCRIPTION
Fix GHA to not incorporate malicious changes by specifying the commit hash when using External Action in GHA, as in  CVE-2023-51664