### PR TITLE
enhancement: MinIO `mc config add` command has been deprecated. replace  `mc alias set`

### DIFF
--- a/aws/compose.yaml
+++ b/aws/compose.yaml
@@ -28,7 +28,7 @@ services:
       - minio
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc config host add s3 http://minio:29000 DUMMYACCESSKEYEXAMPLE DUMMYSECRETKEYEXAMPLE;
+      /usr/bin/mc mc alias set s3 http://minio:29000 DUMMYACCESSKEYEXAMPLE DUMMYSECRETKEYEXAMPLE;
       /usr/bin/mc --quiet mb s3/test;
       /usr/bin/mc --quiet anonymous set upload s3/test;
       /usr/bin/mc --quiet anonymous set download s3/test;


### PR DESCRIPTION
Resolve error during MinIO Setup in CircleCI.
https://github.com/minio/mc/issues/5206
https://min.io/docs/minio/linux/reference/minio-mc/mc-alias-set.html#command-mc.alias.set