### PR TITLE
Fix awss3 copy for reserved S3 object keys

### DIFF
--- a/aws/awss3/awss3_client.go
+++ b/aws/awss3/awss3_client.go
@@ -385,7 +385,7 @@ func (c *Client) Copy(
 	conf := s3upload.GetS3UploadConf(opts...)
 	req := &s3.CopyObjectInput{
 		Bucket:            bucketName.AWSString(),
-		CopySource:        srcKey.BucketJoinAWSString(bucketName),
+		CopySource:        srcKey.bucketJoinEscapedAWSString(bucketName),
 		Key:               destKey.AWSString(),
 		MetadataDirective: types.MetadataDirectiveReplace,
 	}

--- a/aws/awss3/awss3_test.go
+++ b/aws/awss3/awss3_test.go
@@ -798,6 +798,121 @@ func TestCopy(t *testing.T) {
 	})
 }
 
+func TestReservedCharacterKeys(t *testing.T) {
+	t.Parallel()
+	ctx := ctxawslocal.WithContext(
+		context.Background(),
+		ctxawslocal.WithS3Endpoint("http://127.0.0.1:29000"), // use Minio
+		ctxawslocal.WithAccessKey("DUMMYACCESSKEYEXAMPLE"),
+		ctxawslocal.WithSecretAccessKey("DUMMYSECRETKEYEXAMPLE"),
+	)
+	ensureBucket := func(t testing.TB) {
+		t.Helper()
+		s3Client, err := awss3.GetClient(ctx, TestRegion)
+		assert.NilError(t, err)
+
+		_, err = s3Client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(TestBucket)})
+		if err == nil {
+			return
+		}
+
+		_, err = s3Client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(TestBucket)})
+		assert.NilError(t, err)
+	}
+
+	newKey := func(prefix string) awss3.Key {
+		return awss3.Key(fmt.Sprintf("awstest/%s/%s&$@=;:+,?  reserved.txt", prefix, ulid.MustNew()))
+	}
+	readObject := func(t testing.TB, key awss3.Key) string {
+		t.Helper()
+		var buf bytes.Buffer
+		err := awss3.GetObjectWriter(ctx, TestRegion, TestBucket, key, &buf)
+		assert.NilError(t, err)
+		return buf.String()
+	}
+	uploadByPresignedPutObjectURL := func(t testing.TB, presignedURL, body string) {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPut, presignedURL, strings.NewReader(body))
+		assert.NilError(t, err)
+
+		req.Header.Set("Content-Type", "text/plain")
+		resp, err := http.DefaultClient.Do(req)
+		assert.NilError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	ensureBucket(t)
+
+	t.Run("PutObject", func(t *testing.T) {
+		t.Parallel()
+		key := newKey("put-object")
+		body := faker.Sentence()
+
+		_, err := awss3.PutObject(ctx, TestRegion, TestBucket, key, strings.NewReader(body))
+		assert.NilError(t, err)
+		assert.Equal(t, body, readObject(t, key))
+	})
+
+	t.Run("UploadManager", func(t *testing.T) {
+		t.Parallel()
+		key := newKey("upload-manager")
+		body := faker.Sentence()
+
+		_, err := awss3.UploadManager(ctx, TestRegion, TestBucket, key, strings.NewReader(body))
+		assert.NilError(t, err)
+		assert.Equal(t, body, readObject(t, key))
+	})
+
+	t.Run("PresignPutObject", func(t *testing.T) {
+		t.Parallel()
+		key := newKey("presign-put-object")
+		body := faker.Sentence()
+
+		pURL, err := awss3.PresignPutObject(ctx, TestRegion, TestBucket, key)
+		assert.NilError(t, err)
+		assert.Assert(t, pURL != "")
+
+		uploadByPresignedPutObjectURL(t, pURL, body)
+		assert.Equal(t, body, readObject(t, key))
+	})
+
+	t.Run("Multipart upload", func(t *testing.T) {
+		t.Parallel()
+		key := newKey("multipart-upload")
+		body := "This is a multipart upload body."
+
+		uploadID, err := awss3.CreateMultipartUpload(ctx, TestRegion, TestBucket, key)
+		assert.NilError(t, err)
+		assert.Assert(t, uploadID != "")
+
+		partResp, err := awss3.UploadPart(ctx, TestRegion, TestBucket, key, uploadID, 1, strings.NewReader(body))
+		assert.NilError(t, err)
+		assert.Assert(t, partResp != nil)
+
+		_, err = awss3.CompleteMultipartUpload(ctx, TestRegion, TestBucket, key, uploadID, []types.CompletedPart{
+			{ETag: partResp.ETag, PartNumber: aws.Int32(1)},
+		})
+		assert.NilError(t, err)
+		assert.Equal(t, body, readObject(t, key))
+	})
+
+	t.Run("Copy", func(t *testing.T) {
+		t.Parallel()
+		srcKey := newKey("copy-src")
+		destKey := newKey("copy-dest")
+		body := faker.Sentence()
+
+		_, err := awss3.UploadManager(ctx, TestRegion, TestBucket, srcKey, strings.NewReader(body))
+		assert.NilError(t, err)
+
+		err = awss3.Copy(ctx, TestRegion, TestBucket, srcKey, destKey)
+		assert.NilError(t, err)
+		assert.Equal(t, body, readObject(t, destKey))
+	})
+}
+
 func TestSelectCSVAll(t *testing.T) {
 	t.Parallel()
 	type TestCSV string

--- a/aws/awss3/types.go
+++ b/aws/awss3/types.go
@@ -1,6 +1,7 @@
 package awss3
 
 import (
+	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
@@ -31,6 +32,11 @@ func (k Key) AWSString() *string {
 
 func (k Key) BucketJoinAWSString(bucketName BucketName) *string {
 	return aws.String(path.Join(bucketName.String(), k.String()))
+}
+
+func (k Key) bucketJoinEscapedAWSString(bucketName BucketName) *string {
+	escapedKey := strings.ReplaceAll(url.PathEscape(k.String()), "%2F", "/")
+	return aws.String(bucketName.String() + "/" + escapedKey)
 }
 
 func (k Key) Ext() string {

--- a/aws/awss3/types.go
+++ b/aws/awss3/types.go
@@ -35,6 +35,9 @@ func (k Key) BucketJoinAWSString(bucketName BucketName) *string {
 }
 
 func (k Key) bucketJoinEscapedAWSString(bucketName BucketName) *string {
+	// CopySource is bucket/key, so the slash characters that separate S3 path
+	// segments must remain literal even though PathEscape encodes reserved
+	// characters inside each segment.
 	escapedKey := strings.ReplaceAll(url.PathEscape(k.String()), "%2F", "/")
 	return aws.String(bucketName.String() + "/" + escapedKey)
 }


### PR DESCRIPTION
## Why / 背景

**GitHub Issue:** [#390](https://github.com/88labs/go-utils/issues/390)

issue #390 では、`&` や `+` を含む S3 object key を upload-related flow で扱えることが求められています。
Issue #390 asks us to support upload-related S3 flows when S3 object keys contain reserved characters such as `&` and `+`.

現行の `awss3` を再検証したところ、direct upload / presigned PUT / multipart upload は reserved characters を含む key でも動作しましたが、`Copy` だけが `NotFound` で失敗しました。
After revalidating `awss3`, direct upload, presigned PUT, and multipart upload already worked with reserved-character keys, but `Copy` failed with `NotFound`.

## What / 変更内容

### Overview / 概要

`awss3.Copy` が組み立てる `CopySource` を URL-safe な形式に修正し、AWS のガイドラインで特別扱いが必要とされる文字を含む key の回帰テストを追加しました。
This changes `awss3.Copy` so that `CopySource` is built in a URL-safe form and adds regression coverage for keys containing characters that AWS documents as requiring special handling.

### Changes / 変更点

- `awss3.Copy` で使用する `CopySource` を、reserved characters をエスケープした helper 経由で生成するように変更しました。
- Updated `awss3.Copy` to build `CopySource` via a helper that escapes reserved characters.
- `aws/awss3/awss3_test.go` に、reserved-character key を使った `PutObject` / `UploadManager` / `PresignPutObject` / multipart upload / `Copy` の回帰テストを追加しました。
- Added regression tests in `aws/awss3/awss3_test.go` for `PutObject`, `UploadManager`, `PresignPutObject`, multipart upload, and `Copy` using reserved-character keys.
- 新規テストは bucket を自前で確保することで、docker 初期化タイミングへの依存を減らしています。
- The new regression test ensures the bucket exists first so it is less sensitive to docker initialization timing.

### Impact Scope / 影響範囲

**Affected layers / 影響レイヤー:**
- [ ] Handler / API layer
- [ ] Use case / Service layer
- [ ] Repository / Data layer
- [ ] Domain / Model layer
- [x] Infrastructure layer
- [ ] Database Schema Change

## Developer Test / 開発者テスト

- `task test-aws`
- `go test ./awss3 -run '^(TestReservedCharacterKeys|TestPutObject|TestUploadManager|TestCopy|TestPresignPutObject|TestCreateMultipartUpload|TestUploadPart|TestCompleteMultipartUpload)$' -count=1`

## SQL Execution Plan / SQL実行計画

SQL 変更はありません。
There are no SQL changes.

## Other / その他

- AWS object key guideline: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html