### PR TITLE
[#33] feat: add slog and zap logging support to awss3

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -187,6 +187,36 @@ _, err = client.DeleteObject(ctx, bucket, awss3.Key("key.txt"))
 raw := client.S3Client()
 ```
 
+#### Logging
+
+Logging is opt-in. By default, `awss3` does not emit any logs.
+
+When configured, wrapper methods emit structured `slog` records with fields such as `component`, `operation`, `bucket`, `key`, and `duration`.
+
+```go
+import (
+    "log/slog"
+    "os"
+
+    "go.uber.org/zap"
+)
+
+// Package-level helpers use the global logger.
+awss3.GlobalLogger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+_, err := awss3.HeadObject(ctx, region, bucket, awss3.Key("path/to/key.txt"))
+
+// Clients can receive a logger explicitly.
+client, err := awss3.NewClient(ctx, region,
+    awss3.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, nil))),
+)
+
+// Zap can be used via the built-in bridge helpers.
+zapLogger := zap.NewExample()
+
+client, err = awss3.NewClient(ctx, region, awss3.WithZapLogger(zapLogger))
+awss3.GlobalLogger = awss3.NewLoggerFromZap(zapLogger)
+```
+
 #### Error handling
 
 ```go

--- a/aws/README.md
+++ b/aws/README.md
@@ -193,6 +193,8 @@ Logging is opt-in. By default, `awss3` does not emit any logs.
 
 When configured, wrapper methods emit structured `slog` records with fields such as `component`, `operation`, `bucket`, `key`, and `duration`.
 
+Passing `nil` to `WithLogger`, `WithZapLogger`, or `NewLoggerFromZap` falls back to a no-op logger.
+
 ```go
 import (
     "log/slog"

--- a/aws/awss3/awss3.go
+++ b/aws/awss3/awss3.go
@@ -39,7 +39,7 @@ func PutObject(
 	if err != nil {
 		return nil, err
 	}
-	return (&Client{client: c}).PutObject(ctx, bucketName, key, body, opts...)
+	return packageClientFromSDK(c).PutObject(ctx, bucketName, key, body, opts...)
 }
 
 // UploadManager
@@ -54,7 +54,7 @@ func UploadManager(
 	if err != nil {
 		return nil, err
 	}
-	return (&Client{client: c}).UploadManager(ctx, bucketName, key, body, opts...)
+	return packageClientFromSDK(c).UploadManager(ctx, bucketName, key, body, opts...)
 }
 
 // HeadObject
@@ -68,7 +68,7 @@ func HeadObject(
 	if err != nil {
 		return nil, err
 	}
-	return (&Client{client: c}).HeadObject(ctx, bucketName, key, opts...)
+	return packageClientFromSDK(c).HeadObject(ctx, bucketName, key, opts...)
 }
 
 // ListObjects
@@ -82,7 +82,7 @@ func ListObjects(
 	if err != nil {
 		return nil, err
 	}
-	return (&Client{client: c}).ListObjects(ctx, bucketName, opts...)
+	return packageClientFromSDK(c).ListObjects(ctx, bucketName, opts...)
 }
 
 // GetObjectWriter
@@ -94,7 +94,7 @@ func GetObjectWriter(ctx context.Context, region awsconfig.Region, bucketName Bu
 	if err != nil {
 		return err
 	}
-	return (&Client{client: c}).GetObjectWriter(ctx, bucketName, key, w)
+	return packageClientFromSDK(c).GetObjectWriter(ctx, bucketName, key, w)
 }
 
 // DeleteObject
@@ -107,7 +107,7 @@ func DeleteObject(ctx context.Context, region awsconfig.Region, bucketName Bucke
 	if err != nil {
 		return nil, err
 	}
-	return (&Client{client: c}).DeleteObject(ctx, bucketName, key)
+	return packageClientFromSDK(c).DeleteObject(ctx, bucketName, key)
 }
 
 // DownloadFiles
@@ -123,7 +123,7 @@ func DownloadFiles(
 	if err != nil {
 		return nil, err
 	}
-	return (&Client{client: c}).DownloadFiles(ctx, bucketName, keys, outputDir, opts...)
+	return packageClientFromSDK(c).DownloadFiles(ctx, bucketName, keys, outputDir, opts...)
 }
 
 // DownloadFilesParallel
@@ -139,7 +139,7 @@ func DownloadFilesParallel(
 	if err != nil {
 		return nil, err
 	}
-	return (&Client{client: c}).DownloadFilesParallel(ctx, bucketName, keys, outputDir, opts...)
+	return packageClientFromSDK(c).DownloadFilesParallel(ctx, bucketName, keys, outputDir, opts...)
 }
 
 // Presign
@@ -155,7 +155,7 @@ func Presign(
 	if err != nil {
 		return "", err
 	}
-	return (&Client{client: c}).Presign(ctx, bucketName, key, opts...)
+	return packageClientFromSDK(c).Presign(ctx, bucketName, key, opts...)
 }
 
 // Copy copies an Amazon S3 object from one bucket to same.
@@ -169,7 +169,7 @@ func Copy(
 	if err != nil {
 		return err
 	}
-	return (&Client{client: c}).Copy(ctx, bucketName, srcKey, destKey, opts...)
+	return packageClientFromSDK(c).Copy(ctx, bucketName, srcKey, destKey, opts...)
 }
 
 const (
@@ -187,7 +187,7 @@ func SelectCSVAll(
 	if err != nil {
 		return err
 	}
-	return (&Client{client: c}).SelectCSVAll(ctx, bucketName, key, query, w, opts...)
+	return packageClientFromSDK(c).SelectCSVAll(ctx, bucketName, key, query, w, opts...)
 }
 
 // SelectCSVHeaders
@@ -201,7 +201,7 @@ func SelectCSVHeaders(
 	if err != nil {
 		return nil, err
 	}
-	return (&Client{client: c}).SelectCSVHeaders(ctx, bucketName, key, opts...)
+	return packageClientFromSDK(c).SelectCSVHeaders(ctx, bucketName, key, opts...)
 }
 
 func PresignPutObject(
@@ -212,7 +212,7 @@ func PresignPutObject(
 	if err != nil {
 		return "", err
 	}
-	return (&Client{client: c}).PresignPutObject(ctx, bucketName, key, opts...)
+	return packageClientFromSDK(c).PresignPutObject(ctx, bucketName, key, opts...)
 }
 
 // ref: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
@@ -224,7 +224,7 @@ func CreateMultipartUpload(
 		return "", err
 	}
 	_ = opts // opts not used by the SDK call; kept for API compatibility
-	return (&Client{client: c}).CreateMultipartUpload(ctx, bucketName, key)
+	return packageClientFromSDK(c).CreateMultipartUpload(ctx, bucketName, key)
 }
 
 // ref: https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
@@ -236,7 +236,7 @@ func UploadPart(
 	if err != nil {
 		return nil, err
 	}
-	return (&Client{client: c}).UploadPart(ctx, bucketName, key, uploadID, partNumber, body)
+	return packageClientFromSDK(c).UploadPart(ctx, bucketName, key, uploadID, partNumber, body)
 }
 
 // ref: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
@@ -248,7 +248,7 @@ func CompleteMultipartUpload(
 	if err != nil {
 		return nil, err
 	}
-	return (&Client{client: c}).CompleteMultipartUpload(ctx, bucketName, key, uploadID, completedParts)
+	return packageClientFromSDK(c).CompleteMultipartUpload(ctx, bucketName, key, uploadID, completedParts)
 }
 
 // ref: https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
@@ -259,5 +259,5 @@ func AbortMultipartUpload(
 	if err != nil {
 		return err
 	}
-	return (&Client{client: c}).AbortMultipartUpload(ctx, bucketName, key, uploadID)
+	return packageClientFromSDK(c).AbortMultipartUpload(ctx, bucketName, key, uploadID)
 }

--- a/aws/awss3/awss3_client.go
+++ b/aws/awss3/awss3_client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path"
@@ -44,7 +45,15 @@ import (
 func (c *Client) PutObject(
 	ctx context.Context, bucketName BucketName, key Key, body io.Reader,
 	opts ...s3upload.OptionS3Upload,
-) (*s3.PutObjectOutput, error) {
+) (res *s3.PutObjectOutput, err error) {
+	done := c.logOperation(ctx, "PutObject",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err)
+	}()
+
 	conf := s3upload.GetS3UploadConf(opts...)
 	input := &s3.PutObjectInput{
 		Body:   body,
@@ -54,14 +63,23 @@ func (c *Client) PutObject(
 	if conf.S3Expires != nil {
 		input.Expires = aws.Time(time.Now().Add(*conf.S3Expires))
 	}
-	return c.client.PutObject(ctx, input)
+	res, err = c.client.PutObject(ctx, input)
+	return res, err
 }
 
 // UploadManager uploads an object using the transfer manager.
 func (c *Client) UploadManager(
 	ctx context.Context, bucketName BucketName, key Key, body io.Reader,
 	opts ...s3upload.OptionS3Upload,
-) (*transfermanager.UploadObjectOutput, error) {
+) (res *transfermanager.UploadObjectOutput, err error) {
+	done := c.logOperation(ctx, "UploadManager",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err)
+	}()
+
 	conf := s3upload.GetS3UploadConf(opts...)
 	uploader := transfermanager.New(c.client)
 	input := &transfermanager.UploadObjectInput{
@@ -72,11 +90,27 @@ func (c *Client) UploadManager(
 	if conf.S3Expires != nil {
 		input.Expires = aws.Time(time.Now().Add(*conf.S3Expires))
 	}
-	return uploader.UploadObject(ctx, input)
+	res, err = uploader.UploadObject(ctx, input)
+	return res, err
 }
 
 // HeadObject retrieves metadata from an object without returning the object itself.
 func (c *Client) HeadObject(
+	ctx context.Context, bucketName BucketName, key Key, opts ...s3head.OptionS3Head,
+) (res *s3.HeadObjectOutput, err error) {
+	done := c.logOperation(ctx, "HeadObject",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err)
+	}()
+
+	res, err = c.headObject(ctx, bucketName, key, opts...)
+	return res, err
+}
+
+func (c *Client) headObject(
 	ctx context.Context, bucketName BucketName, key Key, opts ...s3head.OptionS3Head,
 ) (*s3.HeadObjectOutput, error) {
 	conf := s3head.GetS3HeadConf(opts...)
@@ -113,15 +147,26 @@ func (c *Client) HeadObject(
 // ListObjects lists objects in a bucket.
 func (c *Client) ListObjects(
 	ctx context.Context, bucketName BucketName, opts ...s3list.OptionS3List,
-) (Objects, error) {
+) (objects Objects, err error) {
 	conf := s3list.GetS3ListConf(opts...)
+	attrs := []slog.Attr{
+		slog.String("bucket", bucketName.String()),
+	}
+	if conf.Prefix != nil {
+		attrs = append(attrs, slog.String("prefix", *conf.Prefix))
+	}
+	done := c.logOperation(ctx, "ListObjects", attrs...)
+	defer func() {
+		done(err, slog.Int("object_count", len(objects)))
+	}()
+
 	input := &s3.ListObjectsV2Input{
 		Bucket: bucketName.AWSString(),
 	}
 	if conf.Prefix != nil {
 		input.Prefix = conf.Prefix
 	}
-	objects := make(Objects, 0)
+	objects = make(Objects, 0)
 	paginator := s3.NewListObjectsV2Paginator(c.client, input)
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(ctx)
@@ -135,7 +180,15 @@ func (c *Client) ListObjects(
 
 // GetObjectWriter downloads an object and writes its content to w.
 func (c *Client) GetObjectWriter(ctx context.Context, bucketName BucketName, key Key, w io.Writer) (err error) {
-	if _, err = c.HeadObject(ctx, bucketName, key); err != nil {
+	done := c.logOperation(ctx, "GetObjectWriter",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err)
+	}()
+
+	if _, err = c.headObject(ctx, bucketName, key); err != nil {
 		return err
 	}
 	resp, err := c.client.GetObject(ctx, &s3.GetObjectInput{
@@ -160,16 +213,25 @@ func (c *Client) GetObjectWriter(ctx context.Context, bucketName BucketName, key
 
 // DeleteObject deletes an object from a bucket.
 func (c *Client) DeleteObject(ctx context.Context, bucketName BucketName, key Key) (
-	*s3.DeleteObjectOutput, error,
+	res *s3.DeleteObjectOutput, err error,
 ) {
-	if _, err := c.HeadObject(ctx, bucketName, key); err != nil {
+	done := c.logOperation(ctx, "DeleteObject",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err)
+	}()
+
+	if _, err = c.headObject(ctx, bucketName, key); err != nil {
 		return nil, err
 	}
 	input := &s3.DeleteObjectInput{
 		Bucket: bucketName.AWSString(),
 		Key:    key.AWSString(),
 	}
-	return c.client.DeleteObject(ctx, input)
+	res, err = c.client.DeleteObject(ctx, input)
+	return res, err
 }
 
 // DownloadFiles downloads multiple objects and saves them to a directory.
@@ -177,13 +239,23 @@ func (c *Client) DeleteObject(ctx context.Context, bucketName BucketName, key Ke
 func (c *Client) DownloadFiles(
 	ctx context.Context, bucketName BucketName, keys Keys, outputDir string,
 	opts ...s3download.OptionS3Download,
-) ([]string, error) {
+) (paths []string, err error) {
+	done := c.logOperation(ctx, "DownloadFiles",
+		slog.String("bucket", bucketName.String()),
+		slog.Int("key_count", len(keys)),
+		slog.String("output_dir", outputDir),
+	)
+	downloadedCount := 0
+	defer func() {
+		done(err, slog.Int("downloaded_file_count", downloadedCount))
+	}()
+
 	conf := s3download.GetS3DownloadConf(opts...)
 	uniqKeys := keys.Unique()
 	downloader := transfermanager.New(c.client, func(o *transfermanager.Options) {
 		o.GetObjectBufferSize = 5 * 1024 * 1024
 	})
-	paths := make([]string, len(uniqKeys))
+	paths = make([]string, len(uniqKeys))
 
 	getFilePath := func(s3Key string) string {
 		fileName := filepath.Base(s3Key)
@@ -236,6 +308,7 @@ func (c *Client) DownloadFiles(
 			}
 			return nil, dlErr
 		}
+		downloadedCount++
 	}
 	return paths, nil
 }
@@ -245,13 +318,23 @@ func (c *Client) DownloadFiles(
 func (c *Client) DownloadFilesParallel(
 	ctx context.Context, bucketName BucketName, keys Keys, outputDir string,
 	opts ...s3download.OptionS3Download,
-) ([]string, error) {
+) (paths []string, err error) {
+	done := c.logOperation(ctx, "DownloadFilesParallel",
+		slog.String("bucket", bucketName.String()),
+		slog.Int("key_count", len(keys)),
+		slog.String("output_dir", outputDir),
+	)
+	downloadedCount := 0
+	defer func() {
+		done(err, slog.Int("downloaded_file_count", downloadedCount))
+	}()
+
 	conf := s3download.GetS3DownloadConf(opts...)
 	uniqKeys := keys.Unique()
 	downloader := transfermanager.New(c.client, func(o *transfermanager.Options) {
 		o.GetObjectBufferSize = 5 * 1024 * 1024
 	})
-	paths := make([]string, len(uniqKeys))
+	paths = make([]string, len(uniqKeys))
 
 	resolveFilePath := func(s3Key string) string {
 		fileName := filepath.Base(s3Key)
@@ -343,6 +426,7 @@ func (c *Client) DownloadFilesParallel(
 	if err := eg.Wait(); err != nil {
 		return nil, err
 	}
+	downloadedCount = len(paths)
 	return paths, nil
 }
 
@@ -351,11 +435,19 @@ func (c *Client) DownloadFilesParallel(
 func (c *Client) Presign(
 	ctx context.Context, bucketName BucketName, key Key,
 	opts ...s3presigned.OptionS3Presigned,
-) (string, error) {
-	if _, err := c.HeadObject(ctx, bucketName, key); err != nil {
+) (url string, err error) {
+	conf := s3presigned.GetS3PresignedConf(opts...)
+	done := c.logOperation(ctx, "Presign",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err, slog.Duration("expires", conf.PresignExpires))
+	}()
+
+	if _, err = c.headObject(ctx, bucketName, key); err != nil {
 		return "", err
 	}
-	conf := s3presigned.GetS3PresignedConf(opts...)
 	input := &s3.GetObjectInput{
 		Bucket: bucketName.AWSString(),
 		Key:    key.AWSString(),
@@ -374,14 +466,24 @@ func (c *Client) Presign(
 	if err != nil {
 		return "", err
 	}
-	return resp.URL, nil
+	url = resp.URL
+	return url, nil
 }
 
 // Copy copies an Amazon S3 object within the same bucket.
 func (c *Client) Copy(
 	ctx context.Context, bucketName BucketName, srcKey, destKey Key,
 	opts ...s3upload.OptionS3Upload,
-) error {
+) (err error) {
+	done := c.logOperation(ctx, "Copy",
+		slog.String("bucket", bucketName.String()),
+		slog.String("src_key", srcKey.String()),
+		slog.String("dest_key", destKey.String()),
+	)
+	defer func() {
+		done(err)
+	}()
+
 	conf := s3upload.GetS3UploadConf(opts...)
 	req := &s3.CopyObjectInput{
 		Bucket:            bucketName.AWSString(),
@@ -410,6 +512,21 @@ func (c *Client) Copy(
 // SelectCSVAll executes a SQL expression against S3 Select and writes results to w.
 // SQL Reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-glacier-select-sql-reference-select.html
 func (c *Client) SelectCSVAll(
+	ctx context.Context, bucketName BucketName, key Key, query string, w io.Writer,
+	opts ...s3selectcsv.OptionS3SelectCSV,
+) (err error) {
+	done := c.logOperation(ctx, "SelectCSVAll",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err)
+	}()
+
+	return c.selectCSVAll(ctx, bucketName, key, query, w, opts...)
+}
+
+func (c *Client) selectCSVAll(
 	ctx context.Context, bucketName BucketName, key Key, query string, w io.Writer,
 	opts ...s3selectcsv.OptionS3SelectCSV,
 ) error {
@@ -474,7 +591,15 @@ func (c *Client) SelectCSVAll(
 func (c *Client) SelectCSVHeaders(
 	ctx context.Context, bucketName BucketName, key Key,
 	opts ...s3selectcsv.OptionS3SelectCSV,
-) ([]string, error) {
+) (headers []string, err error) {
+	done := c.logOperation(ctx, "SelectCSVHeaders",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err, slog.Int("header_count", len(headers)))
+	}()
+
 	conf := s3selectcsv.GetS3SelectCSVConf(opts...)
 	opts = append(opts, s3selectcsv.WithCSVInput(types.CSVInput{
 		AllowQuotedRecordDelimiter: conf.CSVInput.AllowQuotedRecordDelimiter,
@@ -486,11 +611,11 @@ func (c *Client) SelectCSVHeaders(
 		RecordDelimiter:            conf.CSVInput.RecordDelimiter,
 	}))
 	var buf bytes.Buffer
-	if err := c.SelectCSVAll(ctx, bucketName, key, SelectCSVLimit1Query, &buf, opts...); err != nil {
+	if err = c.selectCSVAll(ctx, bucketName, key, SelectCSVLimit1Query, &buf, opts...); err != nil {
 		return nil, err
 	}
 	r := csv.NewReader(&buf)
-	headers, err := r.Read()
+	headers, err = r.Read()
 	if err != nil {
 		return nil, err
 	}
@@ -501,8 +626,16 @@ func (c *Client) SelectCSVHeaders(
 func (c *Client) PresignPutObject(
 	ctx context.Context, bucketName BucketName, key Key,
 	opts ...s3presigned.OptionS3Presigned,
-) (string, error) {
+) (url string, err error) {
 	conf := s3presigned.GetS3PresignedConf(opts...)
+	done := c.logOperation(ctx, "PresignPutObject",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err, slog.Duration("expires", conf.PresignExpires))
+	}()
+
 	input := &s3.PutObjectInput{
 		Bucket: bucketName.AWSString(),
 		Key:    key.AWSString(),
@@ -514,14 +647,23 @@ func (c *Client) PresignPutObject(
 	if err != nil {
 		return "", err
 	}
-	return resp.URL, nil
+	url = resp.URL
+	return url, nil
 }
 
 // CreateMultipartUpload initiates a multipart upload.
 // ref: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
 func (c *Client) CreateMultipartUpload(
 	ctx context.Context, bucketName BucketName, key Key,
-) (string, error) {
+) (uploadID string, err error) {
+	done := c.logOperation(ctx, "CreateMultipartUpload",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err)
+	}()
+
 	input := &s3.CreateMultipartUploadInput{
 		Bucket: bucketName.AWSString(),
 		Key:    key.AWSString(),
@@ -530,7 +672,8 @@ func (c *Client) CreateMultipartUpload(
 	if err != nil {
 		return "", err
 	}
-	return *resp.UploadId, nil
+	uploadID = *resp.UploadId
+	return uploadID, nil
 }
 
 // UploadPart uploads a part in a multipart upload.
@@ -538,7 +681,16 @@ func (c *Client) CreateMultipartUpload(
 func (c *Client) UploadPart(
 	ctx context.Context, bucketName BucketName, key Key, uploadID string, partNumber int32,
 	body io.Reader,
-) (*s3.UploadPartOutput, error) {
+) (res *s3.UploadPartOutput, err error) {
+	done := c.logOperation(ctx, "UploadPart",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+		slog.Int64("part_number", int64(partNumber)),
+	)
+	defer func() {
+		done(err)
+	}()
+
 	input := &s3.UploadPartInput{
 		Bucket:     bucketName.AWSString(),
 		Key:        key.AWSString(),
@@ -550,7 +702,8 @@ func (c *Client) UploadPart(
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+	res = resp
+	return res, nil
 }
 
 // CompleteMultipartUpload completes a multipart upload.
@@ -558,7 +711,16 @@ func (c *Client) UploadPart(
 func (c *Client) CompleteMultipartUpload(
 	ctx context.Context, bucketName BucketName, key Key, uploadID string,
 	completedParts []types.CompletedPart,
-) (*s3.CompleteMultipartUploadOutput, error) {
+) (res *s3.CompleteMultipartUploadOutput, err error) {
+	done := c.logOperation(ctx, "CompleteMultipartUpload",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+		slog.Int("part_count", len(completedParts)),
+	)
+	defer func() {
+		done(err)
+	}()
+
 	input := &s3.CompleteMultipartUploadInput{
 		Bucket:   bucketName.AWSString(),
 		Key:      key.AWSString(),
@@ -571,19 +733,28 @@ func (c *Client) CompleteMultipartUpload(
 	if err != nil {
 		return nil, err
 	}
-	return resp, nil
+	res = resp
+	return res, nil
 }
 
 // AbortMultipartUpload aborts a multipart upload.
 // ref: https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html
 func (c *Client) AbortMultipartUpload(
 	ctx context.Context, bucketName BucketName, key Key, uploadID string,
-) error {
+) (err error) {
+	done := c.logOperation(ctx, "AbortMultipartUpload",
+		slog.String("bucket", bucketName.String()),
+		slog.String("key", key.String()),
+	)
+	defer func() {
+		done(err)
+	}()
+
 	input := &s3.AbortMultipartUploadInput{
 		Bucket:   bucketName.AWSString(),
 		Key:      key.AWSString(),
 		UploadId: aws.String(uploadID),
 	}
-	_, err := c.client.AbortMultipartUpload(ctx, input)
+	_, err = c.client.AbortMultipartUpload(ctx, input)
 	return err
 }

--- a/aws/awss3/client.go
+++ b/aws/awss3/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
+	"log/slog"
 	"net"
 	"sync/atomic"
 
@@ -21,7 +22,10 @@ import (
 
 var (
 	// GlobalDialer Global http dialer settings for awss3 library
-	GlobalDialer   *s3dialer.ConfGlobalDialer
+	GlobalDialer *s3dialer.ConfGlobalDialer
+	// GlobalLogger is used by package-level helpers such as PutObject and HeadObject.
+	// It is nil by default, which disables logging.
+	GlobalLogger   *slog.Logger
 	s3ClientAtomic atomic.Pointer[s3.Client]
 )
 
@@ -30,16 +34,21 @@ var (
 // its own *s3.Client, enabling external lifecycle management.
 type Client struct {
 	client *s3.Client
+	logger *slog.Logger
 }
 
 // NewClient creates a new Client for the given region.
 // Using ctxawslocal.WithContext, you can make requests for local mocks.
-func NewClient(ctx context.Context, region awsconfig.Region) (*Client, error) {
+func NewClient(ctx context.Context, region awsconfig.Region, opts ...ClientOption) (*Client, error) {
+	cfg := defaultClientConfig()
+	for _, opt := range opts {
+		opt.apply(&cfg)
+	}
 	sdkClient, err := newS3Client(ctx, region)
 	if err != nil {
 		return nil, err
 	}
-	return &Client{client: sdkClient}, nil
+	return &Client{client: sdkClient, logger: cfg.logger}, nil
 }
 
 // S3Client returns the underlying *s3.Client for advanced usage.
@@ -126,6 +135,13 @@ func getClientLocal(ctx context.Context, localProfile LocalProfile) (*s3.Client,
 		o.BaseEndpoint = aws.String(localProfile.Endpoint)
 		o.UsePathStyle = true
 	}), nil
+}
+
+func packageClientFromSDK(sdkClient *s3.Client) *Client {
+	return &Client{
+		client: sdkClient,
+		logger: GlobalLogger,
+	}
 }
 
 type LocalProfile struct {

--- a/aws/awss3/client_options.go
+++ b/aws/awss3/client_options.go
@@ -1,11 +1,14 @@
 package awss3
 
 import (
+	"io"
 	"log/slog"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/exp/zapslog"
 )
+
+var noopLogger = slog.New(slog.NewTextHandler(io.Discard, nil))
 
 // ClientOption configures a Client created with NewClient.
 type ClientOption interface {
@@ -29,30 +32,31 @@ func defaultClientConfig() clientConfig {
 }
 
 // WithLogger configures a Client to emit structured logs via slog.
-// Panics if logger is nil.
+// When logger is nil, a no-op logger is used.
 func WithLogger(logger *slog.Logger) ClientOption {
-	if logger == nil {
-		panic("awss3: WithLogger: logger must not be nil")
-	}
 	return clientOptionFunc(func(cfg *clientConfig) {
-		cfg.logger = logger
+		cfg.logger = normalizeLogger(logger)
 	})
 }
 
 // WithZapLogger configures a Client to emit structured logs via a zap logger.
-// Panics if logger is nil.
+// When logger is nil, a no-op logger is used.
 func WithZapLogger(logger *zap.Logger) ClientOption {
-	if logger == nil {
-		panic("awss3: WithZapLogger: logger must not be nil")
-	}
 	return WithLogger(NewLoggerFromZap(logger))
 }
 
 // NewLoggerFromZap bridges a zap logger into slog so it can be used with awss3.
-// Panics if logger is nil.
+// When logger is nil, a no-op logger is returned.
 func NewLoggerFromZap(logger *zap.Logger) *slog.Logger {
 	if logger == nil {
-		panic("awss3: NewLoggerFromZap: logger must not be nil")
+		return noopLogger
 	}
 	return slog.New(zapslog.NewHandler(logger.Core()))
+}
+
+func normalizeLogger(logger *slog.Logger) *slog.Logger {
+	if logger == nil {
+		return noopLogger
+	}
+	return logger
 }

--- a/aws/awss3/client_options.go
+++ b/aws/awss3/client_options.go
@@ -1,0 +1,58 @@
+package awss3
+
+import (
+	"log/slog"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/exp/zapslog"
+)
+
+// ClientOption configures a Client created with NewClient.
+type ClientOption interface {
+	apply(*clientConfig)
+}
+
+type clientConfig struct {
+	logger *slog.Logger
+}
+
+type clientOptionFunc func(*clientConfig)
+
+func (f clientOptionFunc) apply(cfg *clientConfig) {
+	f(cfg)
+}
+
+func defaultClientConfig() clientConfig {
+	return clientConfig{
+		logger: GlobalLogger,
+	}
+}
+
+// WithLogger configures a Client to emit structured logs via slog.
+// Panics if logger is nil.
+func WithLogger(logger *slog.Logger) ClientOption {
+	if logger == nil {
+		panic("awss3: WithLogger: logger must not be nil")
+	}
+	return clientOptionFunc(func(cfg *clientConfig) {
+		cfg.logger = logger
+	})
+}
+
+// WithZapLogger configures a Client to emit structured logs via a zap logger.
+// Panics if logger is nil.
+func WithZapLogger(logger *zap.Logger) ClientOption {
+	if logger == nil {
+		panic("awss3: WithZapLogger: logger must not be nil")
+	}
+	return WithLogger(NewLoggerFromZap(logger))
+}
+
+// NewLoggerFromZap bridges a zap logger into slog so it can be used with awss3.
+// Panics if logger is nil.
+func NewLoggerFromZap(logger *zap.Logger) *slog.Logger {
+	if logger == nil {
+		panic("awss3: NewLoggerFromZap: logger must not be nil")
+	}
+	return slog.New(zapslog.NewHandler(logger.Core()))
+}

--- a/aws/awss3/logging.go
+++ b/aws/awss3/logging.go
@@ -1,0 +1,34 @@
+package awss3
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+func (c *Client) logOperation(ctx context.Context, operation string, attrs ...slog.Attr) func(err error, extra ...slog.Attr) {
+	if c == nil || c.logger == nil {
+		return func(error, ...slog.Attr) {}
+	}
+
+	logger := c.logger.With(slog.String("component", "awss3"))
+	baseAttrs := make([]slog.Attr, 0, len(attrs)+1)
+	baseAttrs = append(baseAttrs, slog.String("operation", operation))
+	baseAttrs = append(baseAttrs, attrs...)
+	startedAt := time.Now()
+
+	return func(err error, extra ...slog.Attr) {
+		logAttrs := make([]slog.Attr, 0, len(baseAttrs)+len(extra)+2)
+		logAttrs = append(logAttrs, baseAttrs...)
+		logAttrs = append(logAttrs, extra...)
+		logAttrs = append(logAttrs, slog.Duration("duration", time.Since(startedAt)))
+
+		if err != nil {
+			logAttrs = append(logAttrs, slog.Any("error", err))
+			logger.LogAttrs(ctx, slog.LevelError, "awss3 operation failed", logAttrs...)
+			return
+		}
+
+		logger.LogAttrs(ctx, slog.LevelInfo, "awss3 operation completed", logAttrs...)
+	}
+}

--- a/aws/awss3/logging_test.go
+++ b/aws/awss3/logging_test.go
@@ -71,6 +71,44 @@ func TestNewClient_WithZapLogger_logsHeadObject(t *testing.T) {
 	assert.Equal(t, fields["key"], key.String())
 }
 
+func TestNewClient_WithNilLogger_usesNoopLogger(t *testing.T) {
+	ctx := newLoggingTestContext()
+	key := uploadLoggingFixture(t, ctx, 16)
+
+	var buf bytes.Buffer
+	awss3.GlobalLogger = slog.New(slog.NewJSONHandler(&buf, nil))
+	t.Cleanup(func() {
+		awss3.GlobalLogger = nil
+	})
+
+	client, err := awss3.NewClient(ctx, TestRegion, awss3.WithLogger(nil))
+	assert.NilError(t, err)
+
+	res, err := client.HeadObject(ctx, TestBucket, key)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, aws.Int64(16), res.ContentLength)
+	assert.Equal(t, strings.TrimSpace(buf.String()), "")
+}
+
+func TestNewClient_WithNilZapLogger_usesNoopLogger(t *testing.T) {
+	ctx := newLoggingTestContext()
+	key := uploadLoggingFixture(t, ctx, 24)
+
+	var buf bytes.Buffer
+	awss3.GlobalLogger = slog.New(slog.NewJSONHandler(&buf, nil))
+	t.Cleanup(func() {
+		awss3.GlobalLogger = nil
+	})
+
+	client, err := awss3.NewClient(ctx, TestRegion, awss3.WithZapLogger(nil))
+	assert.NilError(t, err)
+
+	res, err := client.HeadObject(ctx, TestBucket, key)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, aws.Int64(24), res.ContentLength)
+	assert.Equal(t, strings.TrimSpace(buf.String()), "")
+}
+
 func newLoggingTestContext() context.Context {
 	return ctxawslocal.WithContext(
 		context.Background(),

--- a/aws/awss3/logging_test.go
+++ b/aws/awss3/logging_test.go
@@ -1,0 +1,114 @@
+package awss3_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"gotest.tools/v3/assert"
+
+	"github.com/88labs/go-utils/ulid"
+
+	"github.com/88labs/go-utils/aws/awss3"
+	"github.com/88labs/go-utils/aws/ctxawslocal"
+)
+
+func TestNewClient_WithLogger_logsHeadObject(t *testing.T) {
+	t.Parallel()
+
+	ctx := newLoggingTestContext()
+	key := uploadLoggingFixture(t, ctx, 64)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	client, err := awss3.NewClient(ctx, TestRegion, awss3.WithLogger(logger))
+	assert.NilError(t, err)
+
+	res, err := client.HeadObject(ctx, TestBucket, key)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, aws.Int64(64), res.ContentLength)
+
+	entry := decodeLastJSONLogEntry(t, buf.String())
+	assert.Equal(t, entry["msg"], "awss3 operation completed")
+	assert.Equal(t, entry["component"], "awss3")
+	assert.Equal(t, entry["operation"], "HeadObject")
+	assert.Equal(t, entry["bucket"], TestBucket)
+	assert.Equal(t, entry["key"], key.String())
+}
+
+func TestNewClient_WithZapLogger_logsHeadObject(t *testing.T) {
+	t.Parallel()
+
+	ctx := newLoggingTestContext()
+	key := uploadLoggingFixture(t, ctx, 32)
+
+	core, observedLogs := observer.New(zap.InfoLevel)
+	client, err := awss3.NewClient(ctx, TestRegion, awss3.WithZapLogger(zap.New(core)))
+	assert.NilError(t, err)
+
+	res, err := client.HeadObject(ctx, TestBucket, key)
+	assert.NilError(t, err)
+	assert.DeepEqual(t, aws.Int64(32), res.ContentLength)
+
+	entries := observedLogs.AllUntimed()
+	assert.Equal(t, len(entries), 1)
+	assert.Equal(t, entries[0].Message, "awss3 operation completed")
+
+	fields := entries[0].ContextMap()
+	assert.Equal(t, fields["component"], "awss3")
+	assert.Equal(t, fields["operation"], "HeadObject")
+	assert.Equal(t, fields["bucket"], TestBucket)
+	assert.Equal(t, fields["key"], key.String())
+}
+
+func newLoggingTestContext() context.Context {
+	return ctxawslocal.WithContext(
+		context.Background(),
+		ctxawslocal.WithS3Endpoint("http://127.0.0.1:29000"),
+		ctxawslocal.WithAccessKey("DUMMYACCESSKEYEXAMPLE"),
+		ctxawslocal.WithSecretAccessKey("DUMMYSECRETKEYEXAMPLE"),
+	)
+}
+
+func uploadLoggingFixture(t *testing.T, ctx context.Context, size int) awss3.Key {
+	t.Helper()
+
+	s3Client, err := awss3.GetClient(ctx, TestRegion)
+	assert.NilError(t, err)
+
+	key := awss3.Key(fmt.Sprintf("awstest/%s.txt", ulid.MustNew()))
+	uploader := transfermanager.New(s3Client)
+	input := &transfermanager.UploadObjectInput{
+		Body:    bytes.NewReader(bytes.Repeat([]byte{1}, size)),
+		Bucket:  aws.String(TestBucket),
+		Key:     aws.String(key.String()),
+		Expires: aws.Time(time.Now().Add(10 * time.Minute)),
+	}
+	_, err = uploader.UploadObject(ctx, input)
+	assert.NilError(t, err)
+
+	return key
+}
+
+func decodeLastJSONLogEntry(t *testing.T, raw string) map[string]any {
+	t.Helper()
+
+	lines := strings.Split(strings.TrimSpace(raw), "\n")
+	assert.Assert(t, len(lines) > 0)
+
+	entry := make(map[string]any)
+	err := json.Unmarshal([]byte(lines[len(lines)-1]), &entry)
+	assert.NilError(t, err)
+
+	return entry
+}

--- a/aws/awss3/options/global/logger_test.go
+++ b/aws/awss3/options/global/logger_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/88labs/go-utils/ulid"
 
@@ -55,6 +57,44 @@ func TestGlobalLoggerWithHeadObject(t *testing.T) {
 	assert.Equal(t, "HeadObject", entry["operation"])
 	assert.Equal(t, TestBucket, entry["bucket"])
 	assert.Equal(t, key.String(), entry["key"])
+}
+
+func TestGlobalLoggerWithZapBridgeLogsHeadObject(t *testing.T) {
+	if _, ok := os.LookupEnv("CI"); ok {
+		t.Skip("Skip the test in CI environment.")
+		return
+	}
+
+	ctx := ctxawslocal.WithContext(
+		context.Background(),
+		ctxawslocal.WithS3Endpoint("http://127.0.0.1:29000"),
+		ctxawslocal.WithAccessKey("DUMMYACCESSKEYEXAMPLE"),
+		ctxawslocal.WithSecretAccessKey("DUMMYSECRETKEYEXAMPLE"),
+	)
+	s3Client, err := awss3.GetClient(ctx, TestRegion)
+	assert.NoError(t, err)
+
+	key := createLoggerFixture(t, ctx, s3Client, 80)
+
+	core, observedLogs := observer.New(zap.InfoLevel)
+	awss3.GlobalLogger = awss3.NewLoggerFromZap(zap.New(core))
+	t.Cleanup(func() {
+		awss3.GlobalLogger = nil
+	})
+
+	res, err := awss3.HeadObject(ctx, TestRegion, TestBucket, key)
+	assert.NoError(t, err)
+	assert.Equal(t, aws.Int64(80), res.ContentLength)
+
+	entries := observedLogs.AllUntimed()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "awss3 operation completed", entries[0].Message)
+
+	fields := entries[0].ContextMap()
+	assert.Equal(t, "awss3", fields["component"])
+	assert.Equal(t, "HeadObject", fields["operation"])
+	assert.Equal(t, TestBucket, fields["bucket"])
+	assert.Equal(t, key.String(), fields["key"])
 }
 
 func createLoggerFixture(t *testing.T, ctx context.Context, s3Client *s3.Client, fileSize int) awss3.Key {

--- a/aws/awss3/options/global/logger_test.go
+++ b/aws/awss3/options/global/logger_test.go
@@ -1,0 +1,90 @@
+package global_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/88labs/go-utils/ulid"
+
+	"github.com/88labs/go-utils/aws/awss3"
+	"github.com/88labs/go-utils/aws/ctxawslocal"
+)
+
+func TestGlobalLoggerWithHeadObject(t *testing.T) {
+	if _, ok := os.LookupEnv("CI"); ok {
+		t.Skip("Skip the test in CI environment.")
+		return
+	}
+
+	ctx := ctxawslocal.WithContext(
+		context.Background(),
+		ctxawslocal.WithS3Endpoint("http://127.0.0.1:29000"),
+		ctxawslocal.WithAccessKey("DUMMYACCESSKEYEXAMPLE"),
+		ctxawslocal.WithSecretAccessKey("DUMMYSECRETKEYEXAMPLE"),
+	)
+	s3Client, err := awss3.GetClient(ctx, TestRegion)
+	assert.NoError(t, err)
+
+	key := createLoggerFixture(t, ctx, s3Client, 100)
+
+	var buf bytes.Buffer
+	awss3.GlobalLogger = slog.New(slog.NewJSONHandler(&buf, nil))
+	t.Cleanup(func() {
+		awss3.GlobalLogger = nil
+	})
+
+	res, err := awss3.HeadObject(ctx, TestRegion, TestBucket, key)
+	assert.NoError(t, err)
+	assert.Equal(t, aws.Int64(100), res.ContentLength)
+
+	entry := decodeLastGlobalLogEntry(t, buf.String())
+	assert.Equal(t, "awss3 operation completed", entry["msg"])
+	assert.Equal(t, "awss3", entry["component"])
+	assert.Equal(t, "HeadObject", entry["operation"])
+	assert.Equal(t, TestBucket, entry["bucket"])
+	assert.Equal(t, key.String(), entry["key"])
+}
+
+func createLoggerFixture(t *testing.T, ctx context.Context, s3Client *s3.Client, fileSize int) awss3.Key {
+	t.Helper()
+
+	key := fmt.Sprintf("awstest/%s.txt", ulid.MustNew())
+	uploader := transfermanager.New(s3Client)
+	input := &transfermanager.UploadObjectInput{
+		Body:    bytes.NewReader(bytes.Repeat([]byte{1}, fileSize)),
+		Bucket:  aws.String(TestBucket),
+		Key:     aws.String(key),
+		Expires: aws.Time(time.Now().Add(10 * time.Minute)),
+	}
+	_, err := uploader.UploadObject(ctx, input)
+	assert.NoError(t, err)
+
+	return awss3.Key(key)
+}
+
+func decodeLastGlobalLogEntry(t *testing.T, raw string) map[string]any {
+	t.Helper()
+
+	lines := strings.Split(strings.TrimSpace(raw), "\n")
+	if len(lines) == 0 {
+		t.Fatal("expected at least one log line")
+	}
+
+	entry := make(map[string]any)
+	err := json.Unmarshal([]byte(lines[len(lines)-1]), &entry)
+	assert.NoError(t, err)
+
+	return entry
+}

--- a/aws/awss3/options/global/logger_test.go
+++ b/aws/awss3/options/global/logger_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -25,11 +24,6 @@ import (
 )
 
 func TestGlobalLoggerWithHeadObject(t *testing.T) {
-	if _, ok := os.LookupEnv("CI"); ok {
-		t.Skip("Skip the test in CI environment.")
-		return
-	}
-
 	ctx := ctxawslocal.WithContext(
 		context.Background(),
 		ctxawslocal.WithS3Endpoint("http://127.0.0.1:29000"),
@@ -60,11 +54,6 @@ func TestGlobalLoggerWithHeadObject(t *testing.T) {
 }
 
 func TestGlobalLoggerWithZapBridgeLogsHeadObject(t *testing.T) {
-	if _, ok := os.LookupEnv("CI"); ok {
-		t.Skip("Skip the test in CI environment.")
-		return
-	}
-
 	ctx := ctxawslocal.WithContext(
 		context.Background(),
 		ctxawslocal.WithS3Endpoint("http://127.0.0.1:29000"),

--- a/aws/go.mod
+++ b/aws/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/go-faker/faker/v4 v4.7.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tomtwinkle/utfbomremover v0.1.1
+	go.uber.org/zap v1.27.1
+	go.uber.org/zap/exp v0.3.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.36.0
 	gotest.tools/v3 v3.5.2
@@ -48,6 +50,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/aws/go.sum
+++ b/aws/go.sum
@@ -86,6 +86,14 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tomtwinkle/utfbomremover v0.1.1 h1:GYRMDznAkHQq5sBuzJULO9AsTA84kILhV26dVXsDKtM=
 github.com/tomtwinkle/utfbomremover v0.1.1/go.mod h1:5iCGUVDwbVxfPVTgnMLZ7hZA5U+h1BsrMbkyzOcaz/0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
+go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+go.uber.org/zap/exp v0.3.0 h1:6JYzdifzYkGmTdRR59oYH+Ng7k49H9qVpWwNSsGJj3U=
+go.uber.org/zap/exp v0.3.0/go.mod h1:5I384qq7XGxYyByIhHm6jg5CHkGY0nsTfbDLgDDlgJQ=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=


### PR DESCRIPTION
## Why / 背景

**Issue:** [#33](https://github.com/88labs/go-utils/issues/33)

`aws/awss3` には logger を差し込む仕組みがなく、wrapper レイヤーで S3 操作の成否や所要時間を追いにくい状態でした。issue #33 に合わせて、標準 `log/slog` を中心にした opt-in な logging surface を追加し、Zap も補助 API で扱えるようにします。

`aws/awss3` had no way to inject a logger, which made it hard to observe wrapper-level S3 operations and durations. To address issue #33, this change adds an opt-in logging surface centered on standard `log/slog`, with convenience support for Zap.

## What / 変更内容

### Overview / 概要

package-level helper と `NewClient` の両方で structured logging を有効化できるようにし、`awss3` の各 wrapper operation から `component`, `operation`, `bucket`, `key`, `duration` などの属性を出すようにしました。

This enables structured logging for both package-level helpers and `NewClient`, and emits wrapper-level attributes such as `component`, `operation`, `bucket`, `key`, and `duration`.

### Changes / 変更点

- `awss3.GlobalLogger`, `WithLogger`, `WithZapLogger`, `NewLoggerFromZap` を追加し、`slog` を第一の API として logger 注入を可能にしました。 / Added `awss3.GlobalLogger`, `WithLogger`, `WithZapLogger`, and `NewLoggerFromZap` so callers can inject loggers with `slog` as the primary API.
- `awss3` の各 operation に成功・失敗ログを追加し、内部で再利用する呼び出しは helper に切り出して重複ログを避けました。 / Added success and failure logs across `awss3` operations, and extracted internal helpers to avoid duplicate logs from nested calls.
- package-level helper 経路と `NewClient` 経路の logging test を追加し、`aws/README.md` に `slog`/Zap の利用例を追記しました。 / Added logging tests for both the package-level helper path and the `NewClient` path, and documented `slog`/Zap usage in `aws/README.md`.

### Impact Scope / 影響範囲

**Affected layers / 影響レイヤー:**
- [ ] Handler / API layer
- [ ] Use case / Service layer
- [ ] Repository / Data layer
- [ ] Domain / Model layer
- [x] Infrastructure layer
- [ ] Database Schema Change

影響は `aws/awss3` の client 構築、logging bridge、wrapper 実装、関連テストとドキュメントに限定されます。

The impact is limited to `aws/awss3` client construction, the logging bridge, wrapper implementation, and the related tests and documentation.

## Developer Test / 開発者テスト

- `cd aws && go test ./...`
- `docker compose up -d elasticmq dynamodb dynamodbcreatetable` を起動し、S3 は既存の互換 MinIO (`127.0.0.1:29000`) を利用して実行しました。 / Started `elasticmq` and `dynamodb` via compose, and reused the existing compatible MinIO on `127.0.0.1:29000` for S3-dependent tests.

## SQL Execution Plan / SQL実行計画

該当なし。データベース変更はありません。

N/A. There are no database changes.

## Other / その他

logging は opt-in のため、logger を設定しない既存の呼び出し元の挙動は変わりません。

Logging is opt-in, so existing callers keep the same behavior when no logger is configured.
