### PR TITLE
enhancement: map AlreadyExists to 409 Conflict in cerrors/http

### DIFF
--- a/cerrors/http/transport.go
+++ b/cerrors/http/transport.go
@@ -22,6 +22,8 @@ func ToCommonErrorCode(statusCode int) cerrors.ErrorCode {
 		return cerrors.UnavailableErr
 	case http.StatusTooManyRequests:
 		return cerrors.ResourceExhaustedErr
+	case http.StatusConflict:
+		return cerrors.AlreadyExists
 	default:
 		return cerrors.UnknownErr
 	}
@@ -43,6 +45,8 @@ func ToHttpStatusCode(errCode cerrors.ErrorCode) int {
 		return http.StatusServiceUnavailable
 	case cerrors.ResourceExhaustedErr:
 		return http.StatusTooManyRequests
+	case cerrors.AlreadyExists:
+		return http.StatusConflict
 	default:
 		return http.StatusInternalServerError
 	}

--- a/cerrors/http/transport_test.go
+++ b/cerrors/http/transport_test.go
@@ -73,6 +73,13 @@ func TestToCommonErrorCode(t *testing.T) {
 			want: cerrors.ResourceExhaustedErr,
 		},
 		{
+			name: "StatusConflict",
+			args: args{
+				http.StatusConflict,
+			},
+			want: cerrors.AlreadyExists,
+		},
+		{
 			name: "StatusInternalServerError",
 			args: args{
 				http.StatusInternalServerError,
@@ -132,6 +139,11 @@ func TestToHttpStatusCode(t *testing.T) {
 			name: "ResourceExhaustedErr",
 			args: args{cerrors.ResourceExhaustedErr},
 			want: http.StatusTooManyRequests,
+		},
+		{
+			name: "AlreadyExists",
+			args: args{cerrors.AlreadyExists},
+			want: http.StatusConflict,
 		},
 		{
 			name: "UnknownErr",


### PR DESCRIPTION
## 変更内容

`cerrors/http` の変換に `AlreadyExists` ↔ `409 Conflict` の対応を追加します。

- `ToHttpStatusCode`: `cerrors.AlreadyExists` → `http.StatusConflict`
- `ToCommonErrorCode`: `http.StatusConflict` → `cerrors.AlreadyExists`
- 両方向のテストケースを追加

## 背景

`cerrors.AlreadyExists` はエラーコードとして定義済みですが、`cerrors/http` の変換に case がなく、HTTP へは default（500）に落ちてしまいます。gRPC ↔ HTTP の正準対応表でも `ALREADY_EXISTS` = 409 であり、Connect RPC の `CodeAlreadyExists`（andpad-invoice-management が使用）とも整合します。REST で cerrors を使うプロダクト（equip-estimate 等）が重複登録を 409 で返せるようにするための変更です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)